### PR TITLE
Introduce explicit `FMap` constructor

### DIFF
--- a/src/Test/Falsify/Internal/Generator/Shrinking.hs
+++ b/src/Test/Falsify/Internal/Generator/Shrinking.hs
@@ -193,9 +193,12 @@ shrinkStep = go
     -- The generator is independent of the tree: /no point/ shrinking
     go (Pure _) _ = []
 
+    -- 'fmap' does not affect the tree at all
+    go (FMap _ g) st = go g st
+
     -- Actual shrinking only happens for the primitive generator
     -- We cannot shrink if the value is already minimal.
-    go (Prim f _) (SampleTree s l r) = (\s' -> SampleTree s' l r) <$> f s
+    go (Prim f) (SampleTree s l r) = (\s' -> SampleTree s' l r) <$> f s
 
     -- Finally, for 'Bind' we shrink either the left or the right tree; as is
     -- usual, this introduces a left bias.


### PR DESCRIPTION
We previously had an argument for this in `Prim`, and while that works, it's entangling two separate concerns; didn't really matter for the code too much, but with the explicit constructor it's slightly cleaner, and it matters for the exposition in the paper.