### PR TITLE
Simplify `Range`

### DIFF
--- a/src/Test/Falsify/Nudge.hs
+++ b/src/Test/Falsify/Nudge.hs
@@ -11,7 +11,7 @@ module Test.Falsify.Nudge (
 -------------------------------------------------------------------------------}
 
 data NoOffset = NoOffset
-  deriving stock (Show)
+  deriving stock (Show, Eq)
 
 {-------------------------------------------------------------------------------
   Definition

--- a/src/Test/Falsify/Reexported/Generator/Compound.hs
+++ b/src/Test/Falsify/Reexported/Generator/Compound.hs
@@ -16,7 +16,6 @@ import Control.Monad.State
 import qualified Data.Foldable as Foldable
 
 import Test.Falsify.Internal.Generator
-import Test.Falsify.Nudge
 import Test.Falsify.Range (Range)
 import Test.Falsify.Reexported.Generator.Simple
 
@@ -84,7 +83,7 @@ keepAtLeast n xs
 -------------------------------------------------------------------------------}
 
 -- | Generate list of specified length
-list :: forall o a. NudgeBy o Word => Range o Word -> Gen a -> Gen [a]
+list :: Range Word -> Gen a -> Gen [a]
 list len g = do
     -- We do /NOT/ mark this call to 'integral' as 'withoutShrinking': it could
     -- shrink towards larger values, in which case we really need to generate
@@ -105,4 +104,5 @@ list len g = do
     n <- integral len
     mapMaybe shouldKeep . keepAtLeast (Range.origin len) <$>
       replicateM (fromIntegral n) (mark g)
+
 

--- a/src/Test/Falsify/Reexported/Generator/Simple.hs
+++ b/src/Test/Falsify/Reexported/Generator/Simple.hs
@@ -4,13 +4,12 @@ module Test.Falsify.Reexported.Generator.Simple (
   , integral
   ) where
 
+import Data.Word
 import Data.Bits
 
 import Test.Falsify.Generator.Auxiliary
 import Test.Falsify.Internal.Generator
-import Test.Falsify.Nudge
 import Test.Falsify.Range (Range(..), origin)
-import Data.Word
 
 {-------------------------------------------------------------------------------
   Generators
@@ -27,9 +26,7 @@ bool target = aux <$> prim
     msbSet :: forall a. FiniteBits a => a -> Bool
     msbSet x = testBit x (finiteBitSize (undefined :: a) - 1)
 
-integral :: forall o a.
-     (NudgeBy o a, Integral a, FiniteBits a)
-  => Range o a -> Gen a
+integral :: forall a. (Integral a, FiniteBits a) => Range a -> Gen a
 integral r = aux <$> signedFraction (precisionOf r)
   where
     lo', hi', origin' :: Double

--- a/test/TestSuite/Sanity/Range.hs
+++ b/test/TestSuite/Sanity/Range.hs
@@ -13,15 +13,15 @@ tests = testGroup "TestSuite.Sanity.Range" [
 
 test_num :: Assertion
 test_num = do
-    assertEqual "Range-060" expected060 $ Range.num (0, 6) 0
-    assertEqual "Range-066" expected066 $ Range.num (0, 6) 6
-    assertEqual "Range-063" expected063 $ Range.num (0, 6) 3
+    assertBool "Range-060" $ Range.same expected060 $ Range.num (0, 6) 0
+    assertBool "Range-066" $ Range.same expected066 $ Range.num (0, 6) 6
+    assertBool "Range-063" $ Range.same expected063 $ Range.num (0, 6) 3
 
     assertEqual "origin-060" 0 $ Range.origin expected060
     assertEqual "origin-066" 6 $ Range.origin expected066
     assertEqual "origin-063" 3 $ Range.origin expected063
   where
-    expected060, expected066, expected063 :: Range Word Word
-    expected060 = Range {lo = 0, hi = 6, offset = 0, inverted = False}
-    expected066 = Range {lo = 0, hi = 6, offset = 6, inverted = False}
-    expected063 = Range {lo = 0, hi = 6, offset = 3, inverted = False}
+    expected060, expected066, expected063 :: Range Word
+    expected060 = Range {lo = 0, hi = 6, offset = 0 :: Word, inverted = False}
+    expected066 = Range {lo = 0, hi = 6, offset = 6 :: Word, inverted = False}
+    expected063 = Range {lo = 0, hi = 6, offset = 3 :: Word, inverted = False}


### PR DESCRIPTION
This makes the offset `o` parameter an internal existential. I think this will make the type easier to use.