### PR TITLE
Generator for binary trees

### DIFF
--- a/falsify.cabal
+++ b/falsify.cabal
@@ -32,26 +32,28 @@ common lang
   ghc-options:
       -Wall
       -Wredundant-constraints
+      -Widentities
   build-depends:
       base >= 4.12 && < 4.18
   default-language:
       Haskell2010
   default-extensions:
+      DeriveFoldable
       DeriveFunctor
+      DeriveTraversable
       DerivingStrategies
       DisambiguateRecordFields
-      FlexibleContexts
       FlexibleInstances
       GADTs
       GeneralizedNewtypeDeriving
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
+      PatternSynonyms
       ScopedTypeVariables
       StandaloneDeriving
-      TupleSections
       TypeApplications
-      UndecidableInstances
+      ViewPatterns
 
 library
   import:
@@ -67,6 +69,10 @@ library
       Test.Falsify.Property
       Test.Falsify.Range
       Test.Falsify.SampleTree
+
+      Data.Falsify.List
+      Data.Falsify.Marked
+      Data.Falsify.Tree
 
       -- For consistency with the other tasty runners, we places these modules
       -- in the @Test.Tasty.*@ hiearchy instead of @Test.Falsify.*@.
@@ -112,7 +118,6 @@ test-suite test-falsify
       TestSuite.Sanity.Range
       TestSuite.Sanity.Simple
       TestSuite.Sanity.Tree
-      TestSuite.Util.Predicates
   build-depends:
     , containers
     , data-default

--- a/src/Data/Falsify/List.hs
+++ b/src/Data/Falsify/List.hs
@@ -1,10 +1,11 @@
-module TestSuite.Util.Predicates (
+module Data.Falsify.List (
+    -- * Predicates
     pairwiseAll
   , pairwiseAny
   ) where
 
 {-------------------------------------------------------------------------------
-  Lists
+  Predicates
 -------------------------------------------------------------------------------}
 
 pairwiseAll :: forall a. (a -> a -> Bool) -> [a] -> Bool

--- a/src/Data/Falsify/Marked.hs
+++ b/src/Data/Falsify/Marked.hs
@@ -1,0 +1,68 @@
+-- | Marked elements
+--
+-- Intended for qualified import.
+module Data.Falsify.Marked (
+    Marked(..)
+    -- * Queries
+  , forget
+  , shouldKeep
+  , shouldDrop
+    -- * Dealing with marks
+  , keepAtLeast
+  , countKept
+  ) where
+
+import Control.Monad.State
+import Data.Foldable (toList)
+import Data.Maybe (mapMaybe)
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+data Marked a = Keep a | Drop a
+  deriving stock (Show, Eq, Functor)
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+forget :: Marked a -> a
+forget (Keep x) = x
+forget (Drop x) = x
+
+shouldKeep :: Marked a -> Maybe a
+shouldKeep (Keep a) = Just a
+shouldKeep (Drop _) = Nothing
+
+shouldDrop :: Marked a -> Maybe a
+shouldDrop (Keep _) = Nothing
+shouldDrop (Drop a) = Just a
+
+{-------------------------------------------------------------------------------
+  Dealing with marks
+-------------------------------------------------------------------------------}
+
+-- | Remark elements such that at least @n@ elements are marked 'Keep'
+--
+-- NOTE: This function is polymorphic in any traversable functor @t@; it can
+-- mark individual elements, but it cannot preserve any datatype specific
+-- invariants. For example, see also 'Data.Falsify.Tree.keepAtLeast'.
+keepAtLeast :: forall t a.
+     Traversable t
+  => Word -> t (Marked a) -> t (Marked a)
+keepAtLeast = \n xs ->
+    let kept = countKept xs
+    in if kept >= n
+         then xs
+         else evalState (traverse remark xs) (n - kept)
+  where
+    remark :: Marked a -> State Word (Marked a)
+    remark (Keep x) = return $ Keep x
+    remark (Drop x) = state $ \m -> if m == 0
+                                      then (Drop x, 0)
+                                      else (Keep x, m - 1)
+
+-- | Count how many elements have been marked as 'Keep'
+countKept :: Foldable t => t (Marked a) -> Word
+countKept = fromIntegral . length . mapMaybe shouldKeep . toList

--- a/src/Data/Falsify/Tree.hs
+++ b/src/Data/Falsify/Tree.hs
@@ -1,0 +1,225 @@
+module Data.Falsify.Tree (
+    Tree(Leaf, Branch)
+    -- * Stats
+  , size
+  , weight
+  , height
+    -- * Balancing
+  , isWeightBalanced
+  , isHeightBalanced
+    -- * Dealing with marks
+  , propagate
+  , truncate
+  , keepAtLeast
+    -- * Debugging
+  , draw
+  ) where
+
+import Prelude hiding (drop, truncate)
+
+import Control.Monad.State
+import GHC.Show
+
+import Data.Falsify.Marked (Marked(..))
+
+import qualified Data.Falsify.Marked as Marked
+import qualified Data.Tree as Containers
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+data Tree a =
+    Leaf
+  | Branch_ {-# UNPACK #-} !Stats a (Tree a) (Tree a)
+  deriving stock (Eq, Functor, Foldable, Traversable)
+
+data Stats = Stats {
+      size_   :: {-# UNPACK #-} !Word
+    , height_ :: {-# UNPACK #-} !Word
+    }
+  deriving stock (Show, Eq)
+
+{-------------------------------------------------------------------------------
+  Tree stats
+-------------------------------------------------------------------------------}
+
+-- | Size of the tree
+--
+-- @O(1)@
+size :: Tree a -> Word
+size Leaf              = 0
+size (Branch_ s _ _ _) = size_ s
+
+-- | Weight of the tree
+--
+-- The weight of a tree is simply its size plus one.
+--
+-- @O(1)@
+weight :: Tree a -> Word
+weight = succ . size
+
+-- | Height of the tree
+--
+-- The height of a tree is the maximum length from the root to any of the leafs.
+--
+-- @O(1)@
+height :: Tree a -> Word
+height Leaf              = 0
+height (Branch_ s _ _ _) = height_ s
+
+{-------------------------------------------------------------------------------
+  Pattern synonyms that hide the size argument
+-------------------------------------------------------------------------------}
+
+viewBranch :: Tree a -> Maybe (a, Tree a, Tree a)
+viewBranch Leaf              = Nothing
+viewBranch (Branch_ _ x l r) = Just (x, l, r)
+
+branch :: a -> Tree a -> Tree a -> Tree a
+branch x l r = Branch_ s x l r
+  where
+    s :: Stats
+    s = Stats {
+          size_   = 1 + (size   l   +   size   r)
+        , height_ = 1 + (height l `max` height r)
+        }
+
+pattern Branch :: a -> Tree a -> Tree a -> Tree a
+pattern Branch x l r <- (viewBranch -> Just (x, l, r))
+  where
+    Branch = branch
+
+{-# COMPLETE Leaf, Branch #-}
+
+{-------------------------------------------------------------------------------
+  'Show' instance that depends on the pattern synonyms
+-------------------------------------------------------------------------------}
+
+instance Show a => Show (Tree a) where
+  showsPrec _ Leaf           = showString "Leaf"
+  showsPrec a (Branch x l r) = showParen (a > appPrec) $
+        showString "Branch "
+      . showsPrec appPrec1 x
+      . showSpace
+      . showsPrec appPrec1 l
+      . showSpace
+      . showsPrec appPrec1 r
+
+{-------------------------------------------------------------------------------
+  Balancing
+-------------------------------------------------------------------------------}
+
+-- | Check if the tree is weight-balanced
+--
+-- A tree is weight-balanced if the weights of the subtrees does not differ
+-- by more than a factor 3.
+--
+-- See "Balancing weight-balanced trees", Hirai and Yamamoto, JFP 21(3), 2011.
+isWeightBalanced :: Tree a -> Bool
+isWeightBalanced = checkBalanceCondition isBalanced
+  where
+    delta :: Word
+    delta = 3
+
+    isBalanced :: Tree a -> Tree a -> Bool
+    isBalanced a b = and [
+          delta * weight a >= weight b
+        , delta * weight b >= weight a
+        ]
+
+-- | Check if a tree is height-balanced
+--
+-- A tree is height balanced if the heights of its subtrees do not differ
+-- by more than one.
+isHeightBalanced :: Tree a -> Bool
+isHeightBalanced = checkBalanceCondition isBalanced
+  where
+    isBalanced :: Tree a -> Tree a -> Bool
+    isBalanced a b = or [
+          height a <= height b && height b - height a <= 1
+        , height b <= height a && height b - height a <= 1
+        ]
+
+-- | Internal auxiliary: check given tree balance condition
+--
+-- Property @p l r@ will be checked at every branch in the tree.
+checkBalanceCondition :: forall a. (Tree a -> Tree a -> Bool) -> Tree a -> Bool
+checkBalanceCondition p = go
+  where
+    go :: Tree a -> Bool
+    go Leaf           = True
+    go (Branch _ l r) = and [p l r, go l, go r]
+
+{-------------------------------------------------------------------------------
+  Dealing with marks
+-------------------------------------------------------------------------------}
+
+-- | Propagate 'Drop' marker down the tree
+--
+-- This is useful in conjunction with 'truncate', which truncates entire
+-- subtrees.
+propagate :: Tree (Marked a) -> Tree (Marked a)
+propagate = keep
+  where
+    keep :: Tree (Marked a) -> Tree (Marked a)
+    keep Leaf                  = Leaf
+    keep (Branch (Keep x) l r) = Branch (Keep x) (keep l) (keep r)
+    keep (Branch (Drop x) l r) = Branch (Drop x) (drop l) (drop r)
+
+    drop :: Tree (Marked a) -> Tree (Marked a)
+    drop = fmap (Drop . Marked.forget)
+
+-- | Truncate tree
+--
+-- Whenever we meet an element marked 'Drop', that entire subtree is dropped.
+truncate :: Tree (Marked a) -> Tree a
+truncate = go
+  where
+    go :: Tree (Marked a) -> Tree a
+    go Leaf                  = Leaf
+    go (Branch (Drop _) _ _) = Leaf
+    go (Branch (Keep x) l r) = Branch x (go l) (go r)
+
+-- | Change enough nodes currently marked as 'Drop' to 'Keep' to ensure at
+-- least @n@ nodes are marked 'Keep'.
+--
+-- This function is different from 'Data.Falsify.Marked.keepAtLeast':
+--
+-- * It /requires/ as precondition that any 'Drop' marks must have been
+--   propagated; see 'propagate'.
+-- * It /guarantees/ as postcondition that this property is preserved.
+keepAtLeast :: Word -> Tree (Marked a) -> Tree (Marked a)
+keepAtLeast = \n t ->
+    let kept = Marked.countKept t
+    in if kept >= n
+         then t
+         else evalState (go t) (n - kept)
+  where
+    go :: Tree (Marked a) -> State Word (Tree (Marked a))
+    go   Leaf                  = return Leaf
+    go   (Branch (Keep x) l r) = Branch (Keep x) <$> go l <*> go r
+    go t@(Branch (Drop x) l r) = get >>= \case
+         0 ->
+           -- Nothing left to drop
+           return t
+         n | size t <= n -> do
+          -- We can delete the entire subtree
+          put $ n - size t
+          return $ fmap (Keep . Marked.forget) t
+         n ->  do
+          -- We cannot delete the entire subtree. In order to preserve the
+          -- "drop property", we /must/ mark this node as 'Keep'
+          put $ n - 1
+          Branch (Keep x) <$> go l <*> go r
+
+{-------------------------------------------------------------------------------
+  Debugging
+-------------------------------------------------------------------------------}
+
+draw :: Tree String -> String
+draw = Containers.drawTree . conv
+  where
+    conv :: Tree String -> Containers.Tree String
+    conv Leaf           = Containers.Node "*" []
+    conv (Branch x l r) = Containers.Node x [conv l, conv r]

--- a/src/Test/Falsify/Generator.hs
+++ b/src/Test/Falsify/Generator.hs
@@ -13,6 +13,7 @@ module Test.Falsify.Generator (
   , integral
     -- ** Compound
   , list
+  , tree
     -- ** Specialized shrinking
   , firstThen
     -- ** Primitive

--- a/src/Test/Falsify/Generator/Auxiliary.hs
+++ b/src/Test/Falsify/Generator/Auxiliary.hs
@@ -12,7 +12,7 @@ module Test.Falsify.Generator.Auxiliary (
     Signed(..)
     -- ** @n@-bit words
   , Precision(..)
-  , precisionOf
+  , precisionRequiredToRepresent
   , WordN(..)
     -- ** Fractions
   , Fraction(..)
@@ -54,8 +54,9 @@ newtype Precision = Precision Word8
   deriving stock (Show, Eq, Ord)
   deriving newtype (Num, Enum)
 
-precisionOf :: forall proxy a. FiniteBits a => proxy a -> Precision
-precisionOf _ = Precision (fromIntegral $ finiteBitSize (undefined :: a))
+precisionRequiredToRepresent :: forall a. FiniteBits a => a -> Precision
+precisionRequiredToRepresent x = Precision $ fromIntegral $
+    finiteBitSize (undefined :: a) - countLeadingZeros x
 
 -- | @n@-bit word
 data WordN = WordN Precision Word64

--- a/src/Test/Falsify/Property.hs
+++ b/src/Test/Falsify/Property.hs
@@ -65,11 +65,13 @@ data LogEntry =
 
     -- | Some additional information
   | Info CallStack String
+  deriving (Show)
 
 -- | Log of the events happened during a test run
 --
 -- The events are recorded in reverse chronological order
 newtype Log = Log [LogEntry]
+  deriving (Show)
 
 {-------------------------------------------------------------------------------
   Construction

--- a/src/Test/Falsify/Range.hs
+++ b/src/Test/Falsify/Range.hs
@@ -104,10 +104,8 @@ between (lo, hi) = Range{lo, hi, offset = NoOffset, inverted = False}
 -- | Construct numeric range between specified bounds and with the given origin
 --
 -- The origin must lie within the bounds.
-num :: forall a.
-     (Integral a, Show a, HasCallStack)
-  => (a, a) -> a -> Range a
-num bounds@(x, y) o
+num :: forall a. (Integral a, HasCallStack) => (a, a) -> a -> Range a
+num (x, y) o
   | x < y     = aux x y
   | otherwise = aux y x
   where
@@ -122,12 +120,7 @@ num bounds@(x, y) o
       = error originNotInBounds
 
     originNotInBounds :: String
-    originNotInBounds = concat [
-         "num: origin "
-        , show o
-        , " not within bounds "
-        , show bounds
-        ]
+    originNotInBounds = "origin not within bounds"
 
 {-------------------------------------------------------------------------------
   Modifying ranges

--- a/src/Test/Falsify/Reexported/Generator/Compound.hs
+++ b/src/Test/Falsify/Reexported/Generator/Compound.hs
@@ -2,89 +2,49 @@
 module Test.Falsify.Reexported.Generator.Compound (
     -- * Compound generators
     list
-    -- * Auxiliary: marking elements
-  , Marked(..)
-  , mark
-  , shouldKeep
-  , keepAtLeast
+  , tree
   ) where
 
 import Control.Monad
 import Data.Maybe (mapMaybe)
-import Control.Monad.State
 
-import qualified Data.Foldable as Foldable
-
+import Data.Falsify.Marked (Marked(..))
+import Data.Falsify.Tree (Tree(..))
+import Test.Falsify.Generator.Auxiliary
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Range (Range)
 import Test.Falsify.Reexported.Generator.Simple
 
-import qualified Test.Falsify.Range as Range
+import qualified Data.Falsify.Marked as Marked
+import qualified Data.Falsify.Tree   as Tree
+import qualified Test.Falsify.Range  as Range
 
 {-------------------------------------------------------------------------------
   Auxiliary: marking elements
 -------------------------------------------------------------------------------}
 
-data Marked a = Keep a | Drop a
-
 -- | Mark an element, shrinking towards 'Drop'
 --
 -- This is an ingredient in many of the compound generators.
 mark :: Gen a -> Gen (Marked a)
-mark g = aux <$> bool False <*> g
-  where
-    aux :: Bool -> a -> Marked a
-    aux False = Drop
-    aux True  = Keep
-
-shouldKeep :: Marked a -> Maybe a
-shouldKeep (Keep a) = Just a
-shouldKeep (Drop _) = Nothing
-
--- | Remark elements such that at least @n@ elements are marked 'Keep'
---
--- This does not (cannot) change the order of the elements.
-keepAtLeast :: forall t a. Traversable t => Word -> t (Marked a) -> t (Marked a)
-keepAtLeast n xs
-  | markedAsKeep >= n = xs
-  | otherwise = evalState (traverse remark xs) (n - markedAsKeep)
-  where
-    -- Count how many elements have already been marked as 'Keep'
-    --
-    -- This implies that we are doing two passes over @xs@; perhaps this can be
-    -- avoided using some clever recursive program, but for now it doesn't
-    -- really matter.
-    --
-    -- TODO: Is that really true...? After all, what if we want to lazily
-    -- generate some data structure (at least the spine)? This would force the
-    -- entire thing into memory? I guess this is an unavoidable of generating
-    -- @n@ booleans and then looking at all of them. Probably should just be
-    -- documented.
-    markedAsKeep :: Word
-    markedAsKeep = fromIntegral $
-        length $ mapMaybe shouldKeep $ Foldable.toList xs
-
-    remark :: Marked a -> State Word (Marked a)
-    remark (Keep x) = return $ Keep x
-    remark (Drop x) = state $ \m -> if m == 0
-                                      then (Drop x, 0)
-                                      else (Keep x, m - 1)
+mark g = firstThen Keep Drop <*> g
 
 {-------------------------------------------------------------------------------
   Compound generators
 
-  NOTE: An approach where we generate more elements than we need and then
-  selecting some of them (possibly increasing how many we select as we "shrink")
-  does NOT work: in such an approach, any value we generate but don't look at
-  can trivially shrink to zero ('Minimal'); this means that if we then /do/ want
-  to look at it later (because some other value would have been shrunk), we
-  might only find zeroes: we want to start shrinking that only /after/ we start
+
+  An approach where we generate more elements than we need and then selecting
+  some of them (possibly increasing how many we select as we "shrink") does NOT
+  work: in such an approach, any value we generate but don't look at can
+  trivially shrink to zero ('Minimal'); this means that if we then /do/ want to
+  look at it later (because some other value would have been shrunk), we might
+  only find zeroes: we want to start shrinking that only /after/ we start
   looking at it, otherwise shrinking means nothing.
 -------------------------------------------------------------------------------}
 
 -- | Generate list of specified length
 list :: Range Word -> Gen a -> Gen [a]
-list len g = do
+list len gen = do
     -- We do /NOT/ mark this call to 'integral' as 'withoutShrinking': it could
     -- shrink towards larger values, in which case we really need to generate
     -- more elements. This doesn't really have any downsides: it merely means
@@ -102,7 +62,30 @@ list len g = do
     -- that case, the only way we can get more elements is by "shrinking" @n@
     -- towards a larger number).
     n <- integral len
-    mapMaybe shouldKeep . keepAtLeast (Range.origin len) <$>
-      replicateM (fromIntegral n) (mark g)
+    mapMaybe Marked.shouldKeep . Marked.keepAtLeast (Range.origin len) <$>
+      replicateM (fromIntegral n) (mark gen)
 
+{-------------------------------------------------------------------------------
+  Binary trees
+-------------------------------------------------------------------------------}
 
+-- | Generate binary tree
+tree :: forall a. Range Word -> Gen a -> Gen (Tree a)
+tree size gen = do
+    n <- integral size
+    Tree.truncate . Tree.keepAtLeast (Range.origin size) . Tree.propagate <$>
+      go n
+  where
+    go :: Word -> Gen (Tree (Marked a))
+    go 0 = return Leaf
+    go n = do
+        -- Generate element at the root
+        x <- mark gen
+
+        -- Choose how many elements to put in the left subtree
+        --
+        -- This ranges from none (right-biased) to all (left-biased), shrinking
+        -- towards half the number of elements: hence, towards a balanced tree.
+        inLeft <- integral $ Range.num (0, n - 1) ((n - 1) `div` 2)
+        let inRight = (n - 1) - inLeft
+        Branch x <$> go inLeft <*> go inRight

--- a/src/Test/Falsify/Reexported/Generator/Simple.hs
+++ b/src/Test/Falsify/Reexported/Generator/Simple.hs
@@ -30,7 +30,8 @@ bool target = aux <$> prim
 
 -- | Uniform selection of random value in the specified range
 integral :: forall a. (Integral a, FiniteBits a) => Range a -> Gen a
-integral r = aux <$> signedFraction (precisionOf r)
+integral r =
+    aux <$> signedFraction (precisionRequiredToRepresent $ hi r)
   where
     lo', hi', origin' :: Double
     lo'     = fromIntegral $ lo     r
@@ -40,3 +41,4 @@ integral r = aux <$> signedFraction (precisionOf r)
     aux :: Signed Fraction -> a
     aux (Neg (Fraction f)) = round $ origin' - f * (origin' - lo')
     aux (Pos (Fraction f)) = round $ origin' + f * (hi' - origin')
+

--- a/test/TestSuite/Sanity/Compound.hs
+++ b/test/TestSuite/Sanity/Compound.hs
@@ -5,35 +5,56 @@ import Data.Word
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import qualified Data.List.NonEmpty as NE
+
+import Data.Falsify.List (pairwiseAll)
+import Data.Falsify.Tree (Tree(..))
 import Test.Falsify.Generator (Gen)
 
+import qualified Data.Falsify.Tree       as Tree
 import qualified Test.Falsify.Generator  as Gen
 import qualified Test.Falsify.Range      as Range
 import qualified Test.Falsify.SampleTree as SampleTree
 
-import TestSuite.Util.Predicates
-
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Compound" [
-      testCase "listTowardsShorter" test_listTowardsShorter
-    , testCase "listTowardsLonger"  test_listTowardsLonger
-    , testCase "listTowardsOrigin"  test_listTowardsOrigin
+      testGroup "list" [
+          testCase "towardsShorter"  test_list_towardsShorter
+        , testCase "towardsLonger"   test_list_towardsLonger
+        , testCase "towardsOrigin"   test_list_towardsOrigin
+        ]
+    , testGroup "tree" [
+          testCase "towardsSmaller1" test_tree_towardsSmaller1
+        , testCase "towardsSmaller2" test_tree_towardsSmaller2
+        , testCase "towardsOrigin1"  test_tree_towardsOrigin1
+        , testCase "towardsOrigin2"  test_tree_towardsOrigin2
+        ]
     ]
 
-test_listTowardsShorter :: Assertion
-test_listTowardsShorter = do
-    -- Note that [6, 4] is indeed the minimal counter-example to a sorted list,
-    -- when the elements are drawn from the range [0, 10] with origin 5, and
-    -- filtered for even numbers.
-    let expectedHistory = [4,6,6,6,8,4] :| [
-            [4,6,8,6,6,8,4] -- the /filtered/ list can grow in size!
-          , [6,8,6,6,8,4]
-          , [8,6,6,8,4]
-          , [6,6,8,4]
-          , [6,8,4]
-          , [8,4]
-           ,[6,4]
-           ]
+{-------------------------------------------------------------------------------
+  Lists
+-------------------------------------------------------------------------------}
+
+test_list_towardsShorter :: Assertion
+test_list_towardsShorter = do
+    -- [6, 4] is the minimal counter-example to a sorted list, when the elements
+    -- are drawn from the range [0, 10] with origin 5, and filtered for even.
+    --
+    -- In principle the filtered list could /grow/ in size during shrinking (if
+    -- a previously odd number is shrunk to be even).
+    let expectedHistory = [6,8,8,2,10,2,2] :| [
+            [6,8,8,2,10,2]
+          , [6,8,8,2]
+          , [8,8,2]
+          , [8,2]
+          , [4,2]
+          , [6,2]
+          , [6,4]
+          ]
+     -- The 'nub' call here is still necessary; I guess because we are shrinking
+     -- markers that we are not actually using? Might need to think about how
+     -- to optimize that at some point, although this might be difficult:
+     -- shrinking only values that are /used/ is hard.
     assertEqual "shrink" expectedHistory $
       nub $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 1)
   where
@@ -45,16 +66,14 @@ test_listTowardsShorter = do
     prop :: [Word8] -> Bool
     prop = pairwiseAll (<=)
 
-
-test_listTowardsLonger :: Assertion
-test_listTowardsLonger = do
-    let expectedHistory = [0,1,1,1,1,0,1] :| [
-            [0,1,1,1,1,0,1,0,1,1] -- we increase the list length to max immediately
-          , [0,0,1,1,1,0,1,0,1,1] -- .. and then shrink towards exactly one 1
-          , [0,0,0,1,1,0,1,0,1,1]
-          , [0,0,0,0,1,0,1,0,1,1]
-          , [0,0,0,0,0,0,1,0,1,1]
-          , [0,0,0,0,0,0,1,0,0,0]
+test_list_towardsLonger :: Assertion
+test_list_towardsLonger = do
+    -- We increase the list length to max immediately, and then shrink towards
+    -- exactly one 1.
+    let expectedHistory = [0,1,1,0,0,0] :| [
+            [0,1,1,0,0,0,0,0,1,1]
+          , [0,0,1,0,0,0,0,0,1,1]
+          , [0,0,1,0,0,0,0,0,0,0]
           ]
     assertEqual "shrink" expectedHistory $
       nub $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 3)
@@ -66,17 +85,143 @@ test_listTowardsLonger = do
     prop :: [Word8] -> Bool
     prop = pairwiseAll (<=)
 
-
-test_listTowardsOrigin :: Assertion
-test_listTowardsOrigin = do
-    let expectedHistory = [1,0] :| [[1,0,0,1,0],[0,0,0,1,0]]
+test_list_towardsOrigin :: Assertion
+test_list_towardsOrigin = do
+    let expectedHistory = [5,5,5,0] :| [
+            [5,5,5,0,0]
+          , [0,5,5,0,0]
+          , [0,0,5,0,0]
+          , [0,0,2,0,0]
+          , [0,0,1,0,0]
+          ]
     assertEqual "shrink" expectedHistory $
-      nub $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 8)
+      nub $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 14)
   where
     gen :: Gen [Word8]
     gen = Gen.list (Range.num (0, 10) 5) $
-            Gen.integral $ Range.between (0, 1)
+            Gen.integral $ Range.between (0, 10)
 
     prop :: [Word8] -> Bool
     prop = pairwiseAll (<=)
+
+{-------------------------------------------------------------------------------
+  Tree
+-------------------------------------------------------------------------------}
+
+test_tree_towardsSmaller1 :: Assertion
+test_tree_towardsSmaller1 = do
+    assertEqual "" expected $
+      NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    expected :: Tree Word8
+    expected =
+        Branch 0
+          (Branch 0 Leaf Leaf)
+          Leaf
+
+    gen :: Gen (Tree Word8)
+    gen = Gen.tree (Range.between (0, 100)) $
+            Gen.integral $ Range.between (0, 1)
+
+    prop :: Tree Word8 -> Bool
+    prop = Tree.isHeightBalanced
+
+test_tree_towardsSmaller2 :: Assertion
+test_tree_towardsSmaller2 = do
+    assertEqual "" expected $
+      NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    -- For a minimal tree that is not weight-balanced, we need three elements in
+    -- one subtree and none in the other: the weight of the empty tree is 1,
+    -- the weight of the tree with three elements is 4, and 4 > Δ * 1, for Δ=3.
+    expected :: Tree Word8
+    expected =
+        Branch 0
+          (Branch 0
+             Leaf
+             (Branch 0
+                Leaf
+                (Branch 0 Leaf Leaf)
+             )
+          )
+          Leaf
+
+    gen :: Gen (Tree Word8)
+    gen = Gen.tree (Range.between (0, 100)) $
+            Gen.integral $ Range.between (0, 1)
+
+    prop :: Tree Word8 -> Bool
+    prop = Tree.isWeightBalanced
+
+test_tree_towardsOrigin1 :: Assertion
+test_tree_towardsOrigin1 = do
+    assertEqual "" expected $
+      NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    -- If we prefer a counter-example with 10 nodes, then this tree is indeed
+    -- nicely minimal: note that the tree is /almost/ balanced, it's off by
+    -- the minimum amount that would make it unbalanced.
+    expected :: Tree Word8
+    expected =
+        Branch 0
+          (Branch 0
+             (Branch 0 Leaf Leaf)
+             (Branch 0
+                Leaf
+                (Branch 0 Leaf Leaf))
+          )
+          (Branch 0
+             (Branch 0
+                Leaf
+                (Branch 0 Leaf Leaf)
+             )
+             (Branch 0
+                 (Branch 0 Leaf Leaf)
+                 Leaf
+             )
+          )
+
+    gen :: Gen (Tree Word8)
+    gen = Gen.tree (Range.num (0, 100) 10) $
+            Gen.integral $ Range.between (0, 1)
+
+    prop :: Tree Word8 -> Bool
+    prop = Tree.isHeightBalanced
+
+test_tree_towardsOrigin2 :: Assertion
+test_tree_towardsOrigin2 = do
+    assertEqual "" expected $
+      NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    -- Another beautiful example of a tree that is /not/ weight-balanced, but
+    -- only barely so, with as side condition that we prefer to have 10 elements
+    -- (and therefore /get/ 10 elements). The left subtree has one element,
+    -- and therefore weight 2; the right subtree has 8 elements, and therefore
+    -- weight 9, and 9 > Δ * 2 (for Δ=3). This tree indeed /just/ violates
+    -- the weight-balancing property, whilst also having 10 elements.
+    expected :: Tree Word8
+    expected =
+        Branch 0
+           (Branch 0 Leaf Leaf)
+           (Branch 0
+              (Branch 0
+                 (Branch 0 Leaf Leaf)
+                 (Branch 0 Leaf Leaf)
+              )
+              (Branch 0
+                 (Branch 0 Leaf Leaf)
+                 (Branch 0
+                    Leaf
+                    (Branch 0 Leaf Leaf))
+                 )
+           )
+
+    gen :: Gen (Tree Word8)
+    gen = Gen.tree (Range.num (0, 100) 10) $
+            Gen.integral $ Range.between (0, 1)
+
+    prop :: Tree Word8 -> Bool
+    prop = Tree.isWeightBalanced
+
+
 

--- a/test/TestSuite/Sanity/Prim.hs
+++ b/test/TestSuite/Sanity/Prim.hs
@@ -9,14 +9,13 @@ import Test.Tasty.HUnit
 
 import qualified Data.Set as Set
 
+import Data.Falsify.List (pairwiseAll, pairwiseAny)
 import Test.Falsify.Debugging
 import Test.Falsify.Generator (Gen)
 import Test.Falsify.SampleTree (SampleTree, Sample (..))
 
 import qualified Test.Falsify.Generator  as Gen
 import qualified Test.Falsify.SampleTree as SampleTree
-
-import TestSuite.Util.Predicates
 
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Prim" [
@@ -113,9 +112,7 @@ test_list_sorted = do
         E)) E)) E)
 
     gen :: Int -> Gen [Word64]
-    gen n =
-        catMaybes <$>
-          replicateM (fromIntegral n) (aux <$> Gen.prim <*> Gen.prim)
+    gen n = catMaybes <$> replicateM n (aux <$> Gen.prim <*> Gen.prim)
       where
         aux :: Word64 -> Word64 -> Maybe Word64
         aux 0 = const Nothing

--- a/test/TestSuite/Sanity/Simple.hs
+++ b/test/TestSuite/Sanity/Simple.hs
@@ -1,6 +1,6 @@
 module TestSuite.Sanity.Simple (tests) where
 
-import Data.List.NonEmpty (NonEmpty((:|)), nub)
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Word
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -55,14 +55,9 @@ test_integral = do
     -- Note that we are shrinking to a perfect minimal counter-example here: the
     -- 6 and 3 are at their "minimal" value, and if we were to shrink that 1 any
     -- further, it would no longer be a counter-example.
-    let expectedHistory = (6, 6, 6) :| [
-            (3, 6, 6)
-          , (2, 6, 6)
-          , (1, 6, 6)
-          , (1, 6, 3)
-          ]
+    let expectedHistory = (6,6,6) :| [(3,6,6),(1,6,6),(1,6,6),(1,6,3)]
     assertEqual "shrink" expectedHistory $
-      nub $ Gen.shrink (not . prop) gen (tree (maxBound - 1))
+      Gen.shrink (not . prop) gen (tree (maxBound - 1))
   where
     gen :: Gen (Word, Word, Word)
     gen = (,,)


### PR DESCRIPTION
These trees shrink well: they can drop arbitrary subtrees (whilst respecting the bounds on the range of the number of elements in the tree), and will tend to shrink towards balanced trees.