### PR TITLE
Improve test driver

### DIFF
--- a/demo/Demo/HowToSpecifyIt.hs
+++ b/demo/Demo/HowToSpecifyIt.hs
@@ -1,0 +1,36 @@
+-- | Examples from "How to Specify It!: A Guide to Writing Properties of Pure
+-- Functions", John Hughes, 2020, LNCS 12053.
+module Demo.HowToSpecifyIt (tests) where
+
+import Data.Default
+import Test.Tasty
+import Test.Tasty.Falsify
+
+import qualified Test.Falsify.Generator as Gen
+import qualified Test.Falsify.Range     as Range
+
+tests :: TestTree
+tests = testGroup "Demo.HowToSpecifyIt" [
+      testGroup "Section2" [
+          testProperty
+            "reverse_reverse" prop_reverse_reverse
+        , testPropertyWith (def { expectFailure = ExpectFailure })
+            "reverse_id"      prop_reverse_id
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Section 2: "A Primer in Property-Based Testing"
+-------------------------------------------------------------------------------}
+
+forAllLists :: ([Int] -> Bool) -> Property ()
+forAllLists p = do
+    xs <- gen $ Gen.list (Range.between (0, 100)) $
+            Gen.enum (Range.between (0, 100))
+    assert (show xs) $ p xs
+
+prop_reverse_reverse :: Property ()
+prop_reverse_reverse = forAllLists $ \xs -> reverse (reverse xs) == xs
+
+prop_reverse_id :: Property ()
+prop_reverse_id = forAllLists $ \xs -> reverse xs == xs

--- a/demo/Demo/Simple.hs
+++ b/demo/Demo/Simple.hs
@@ -1,0 +1,33 @@
+module Demo.Simple (tests) where
+
+import Data.Default
+import Test.Tasty
+import Test.Tasty.Falsify
+
+import qualified Test.Falsify.Generator as Gen
+import qualified Test.Falsify.Range     as Range
+
+tests :: TestTree
+tests = testGroup "Demo.Simple" [
+      testProperty
+        "even"                 prop_even
+    , testPropertyWith (def { expectFailure = ExpectFailure })
+       "even_expectFailure"    prop_even
+    , testPropertyWith (def { overrideVerbose = Just Verbose })
+       "inRange"               prop_inRange
+    , testPropertyWith (def { expectFailure = ExpectFailure })
+       "inRange_expectFailure" prop_inRange
+    ]
+
+-- | "Every value between 0 and 100 is even"
+prop_even :: Property ()
+prop_even = do
+    x :: Word <- gen $ Gen.integral $ Range.num (0, 100) 0
+    assert ("not even: " ++ show x) $ even x
+
+-- | "Every value between 0 and 100 is between 0 and 100"
+prop_inRange :: Property ()
+prop_inRange = do
+    x :: Word <- gen $ Gen.integral $ Range.num (0, 100) 0
+    assert ("not in range: " ++ show x) $ 0 <= x && x <= 100
+

--- a/demo/Main.hs
+++ b/demo/Main.hs
@@ -1,38 +1,12 @@
 module Main (main) where
 
-import Data.Default
 import Test.Tasty
-import Test.Tasty.Falsify
 
--- TODO: Some of these imports should not be necessary; Test.Tasty.Falsify
--- should (re-)export them.
-
-import Test.Falsify.Property
-
-import qualified Test.Falsify.Generator as Gen
-import qualified Test.Falsify.Range     as Range
+import qualified Demo.Simple
+import qualified Demo.HowToSpecifyIt
 
 main :: IO ()
 main = defaultMain $ testGroup "demo" [
-      testProperty
-        "even"                 prop_even
-    , testPropertyWith (def { expectFailure = ExpectFailure })
-       "even_expectFailure"    prop_even
-    , testPropertyWith (def { overrideVerbose = Just Verbose })
-       "inRange"               prop_inRange
-    , testPropertyWith (def { expectFailure = ExpectFailure })
-       "inRange_expectFailure" prop_inRange
+      Demo.Simple.tests
+    , Demo.HowToSpecifyIt.tests
     ]
-
--- | "Every value between 0 and 100 is even"
-prop_even :: Property String ()
-prop_even = do
-    x :: Word <- gen $ Gen.integral $ Range.num (0, 100) 0
-    assert ("not even: " ++ show x) $ even x
-
--- | "Every value between 0 and 100 is between 0 and 100"
-prop_inRange :: Property String ()
-prop_inRange = do
-    x :: Word <- gen $ Gen.integral $ Range.num (0, 100) 0
-    assert ("not in range: " ++ show x) $ 0 <= x && x <= 100
-

--- a/falsify.cabal
+++ b/falsify.cabal
@@ -50,6 +50,7 @@ common lang
       MultiParamTypeClasses
       NamedFieldPuns
       PatternSynonyms
+      RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
       TypeApplications
@@ -133,6 +134,9 @@ executable demo
       demo
   main-is:
       Main.hs
+  other-modules:
+      Demo.Simple
+      Demo.HowToSpecifyIt
   build-depends:
     , data-default
     , falsify

--- a/src/Test/Falsify/Generator.hs
+++ b/src/Test/Falsify/Generator.hs
@@ -11,6 +11,7 @@ module Test.Falsify.Generator (
     -- * Simple (non-compound)
   , bool
   , integral
+  , enum
     -- ** Compound
   , list
   , tree

--- a/src/Test/Falsify/Nudge.hs
+++ b/src/Test/Falsify/Nudge.hs
@@ -3,7 +3,9 @@
 -- Intended for unqualified import.
 module Test.Falsify.Nudge (
     NudgeBy(..)
+    -- * Offsets
   , NoOffset(..)
+  , Offset(..)
   ) where
 
 {-------------------------------------------------------------------------------
@@ -11,6 +13,9 @@ module Test.Falsify.Nudge (
 -------------------------------------------------------------------------------}
 
 data NoOffset = NoOffset
+  deriving stock (Show, Eq)
+
+newtype Offset a = Offset a
   deriving stock (Show, Eq)
 
 {-------------------------------------------------------------------------------
@@ -25,7 +30,7 @@ instance NudgeBy NoOffset a where
   nudgeUp   NoOffset = id
   nudgeDown NoOffset = id
 
-instance Num a => NudgeBy Word a where
-  nudgeUp   o x = x + fromIntegral o
-  nudgeDown o x = x - fromIntegral o
+instance Num a => NudgeBy (Offset a) a where
+  nudgeUp   (Offset o) x = x + o
+  nudgeDown (Offset o) x = x - o
 

--- a/src/Test/Falsify/Property.hs
+++ b/src/Test/Falsify/Property.hs
@@ -8,7 +8,6 @@ module Test.Falsify.Property (
     -- * Property
     Property -- opaque
   , runProperty
-  , mapFailure
     -- * Log
   , Log(..)
   , LogEntry(..)
@@ -35,23 +34,20 @@ import Test.Falsify.Generator (Gen)
 --
 -- A 'Property' is a generator that can fail and keeps a log of what happened
 -- during a test run.
-newtype Property e a = Property {
-    unwrapProperty :: ExceptT e (StateT Log Gen) a
+newtype Property a = Property {
+    unwrapProperty :: ExceptT String (StateT Log Gen) a
   }
   deriving newtype (Functor, Applicative, Monad)
 
 -- | Construct property
 --
 -- This is a low-level function for internal use only.
-mkProperty :: (Log -> Gen (Either e a, Log)) -> Property e a
+mkProperty :: (Log -> Gen (Either String a, Log)) -> Property a
 mkProperty = Property . ExceptT . StateT
 
 -- | Run property
-runProperty :: Property e a -> Gen (Either e a, Log)
+runProperty :: Property a -> Gen (Either String a, Log)
 runProperty = flip runStateT (Log []) . runExceptT . unwrapProperty
-
-mapFailure :: (e -> e') -> Property e a -> Property e' a
-mapFailure f (Property p) = Property (withExceptT f p)
 
 {-------------------------------------------------------------------------------
   Log
@@ -78,20 +74,20 @@ newtype Log = Log [LogEntry]
 -------------------------------------------------------------------------------}
 
 -- | Generate value and add it to the log
-gen :: (HasCallStack, Show a) => Gen a -> Property e a
+gen :: (HasCallStack, Show a) => Gen a -> Property a
 gen = genWith show
 
 -- | Generalization of 'gen' that doesn't depend on a 'Show' instance
-genWith :: forall e a. HasCallStack => (a -> String) -> Gen a -> Property e a
+genWith :: forall a. HasCallStack => (a -> String) -> Gen a -> Property a
 genWith f g = mkProperty $ \log -> aux log <$> g
   where
-    aux :: Log -> a -> (Either e a, Log)
+    aux :: Log -> a -> (Either String a, Log)
     aux (Log log) x = (Right x, Log $ Generated callStack (f x) : log)
 
 -- | Log some additional information about the test
 --
 -- This will be shown in verbose mode.
-info :: HasCallStack => String -> Property e ()
+info :: HasCallStack => String -> Property ()
 info msg =
     mkProperty $ \(Log log) ->
       return (Right (), Log $ Info callStack msg : log)
@@ -99,6 +95,7 @@ info msg =
 -- | Assert boolean
 --
 -- If the property is false, the test fails.
-assert :: e -> Bool -> Property e ()
+assert :: String -> Bool -> Property ()
 assert _ True  = return ()
 assert e False = mkProperty $ \log -> return (Left e, log)
+

--- a/src/Test/Tasty/Falsify.hs
+++ b/src/Test/Tasty/Falsify.hs
@@ -11,13 +11,13 @@ module Test.Tasty.Falsify (
   , Verbose(..)
   , ExpectFailure(..)
   , testPropertyWith
-    -- * Render success and failure
-  , ShowSuccess(..)
-  , ShowFailure(..)
-
-    -- TODO: Docs
-    -- TODO: Re-exports
+    -- * Re-exports
+    -- ** Properties
+  , Property -- opaque
+  , gen
+  , assert
   ) where
 
 import Test.Falsify.Internal.Tasty
+import Test.Falsify.Property
 

--- a/test/TestSuite/Sanity/Range.hs
+++ b/test/TestSuite/Sanity/Range.hs
@@ -3,8 +3,10 @@ module TestSuite.Sanity.Range (tests) where
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import qualified Test.Falsify.Range as Range
+import Test.Falsify.Nudge
 import Test.Falsify.Range
+
+import qualified Test.Falsify.Range as Range
 
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Range" [
@@ -22,6 +24,6 @@ test_num = do
     assertEqual "origin-063" 3 $ Range.origin expected063
   where
     expected060, expected066, expected063 :: Range Word
-    expected060 = Range {lo = 0, hi = 6, offset = 0 :: Word, inverted = False}
-    expected066 = Range {lo = 0, hi = 6, offset = 6 :: Word, inverted = False}
-    expected063 = Range {lo = 0, hi = 6, offset = 3 :: Word, inverted = False}
+    expected060 = Range {lo = 0, hi = 6, offset = Offset (0 :: Word), inverted = False}
+    expected066 = Range {lo = 0, hi = 6, offset = Offset (6 :: Word), inverted = False}
+    expected063 = Range {lo = 0, hi = 6, offset = Offset (3 :: Word), inverted = False}


### PR DESCRIPTION
It was a bit more polymorphic than it really needed to be.

This also starts the How To Specify It paper, but only the first section so far.

Finally, this improved the `Range` infrastructure somewhat, and uses this to provide `fromEnum` alongside `fromIntegral`.