### PR TITLE
Introduce `ShrinkStep`

### DIFF
--- a/falsify.cabal
+++ b/falsify.cabal
@@ -55,6 +55,7 @@ common lang
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
+      TupleSections
       TypeApplications
       ViewPatterns
 
@@ -84,6 +85,7 @@ library
       Test.Falsify.Internal.Generator
       Test.Falsify.Internal.Generator.Definition
       Test.Falsify.Internal.Generator.Shrinking
+      Test.Falsify.Internal.Generator.ShrinkStep
       Test.Falsify.Internal.Generator.Truncated
       Test.Falsify.Internal.Property
       Test.Falsify.Internal.Search

--- a/src/Test/Falsify/Debugging.hs
+++ b/src/Test/Falsify/Debugging.hs
@@ -16,11 +16,8 @@ module Test.Falsify.Debugging (
   , ShrinkExplanation(..)
   , IsValidShrink(..)
   , shrinkExplain
-  , shrinkStep
   , limitShrinkSteps
   , shrinkHistory
-  , Shortcut
-  , shortcutMinimal
   ) where
 
 import Test.Falsify.Internal.Generator.Definition

--- a/src/Test/Falsify/Driver.hs
+++ b/src/Test/Falsify/Driver.hs
@@ -27,6 +27,7 @@ import Test.Falsify.SampleTree (SampleTree)
 
 import qualified Test.Falsify.Generator  as Gen
 import qualified Test.Falsify.SampleTree as SampleTree
+import qualified Test.Falsify.Internal.Generator.ShrinkStep as Step
 
 {-------------------------------------------------------------------------------
   Options
@@ -118,8 +119,13 @@ falsify opts prop = do
           -- message before shrinking, which we are typically not interested in.
           Left _-> do
             let explanation :: ShrinkExplanation (String, TestRun) TestRun
-                explanation = limitShrinkSteps (maxShrinks opts) . second snd $
-                    shrinkExplain shortcutMinimal isValid (runProperty prop) st
+                explanation =
+                    limitShrinkSteps (maxShrinks opts) . second snd $
+                      shrinkExplain
+                        Step.shortcutMinimal
+                        isValid
+                        (runProperty prop)
+                        st
 
                 failure :: Failure
                 failure = Failure {

--- a/src/Test/Falsify/Generator.hs
+++ b/src/Test/Falsify/Generator.hs
@@ -17,7 +17,7 @@ module Test.Falsify.Generator (
   , list
   , tree
     -- ** User-specified shrinking
-  , shrinkTo
+  , shrinkToOneOf
   , firstThen
   , shrinkWith
     -- ** Primitive

--- a/src/Test/Falsify/Generator/Auxiliary.hs
+++ b/src/Test/Falsify/Generator/Auxiliary.hs
@@ -23,7 +23,7 @@ module Test.Falsify.Generator.Auxiliary (
   , fraction
   , signedFraction
     -- * User-specified shrinking
-  , shrinkTo
+  , shrinkToOneOf
   , firstThen
   , shrinkWith
   ) where
@@ -169,26 +169,55 @@ signedFraction p = fmap mkFraction <$> signedWordN p
   Specialized shrinking behaviour
 -------------------------------------------------------------------------------}
 
--- | Start with @x@, then shrink to any of the @xs@
+-- | Start with @x@, then shrink to one of the @xs@
 --
--- Once shrunk, cannot shrink any further.
-shrinkTo :: forall a. a -> [a] -> Gen a
-shrinkTo x xs =
+-- Once shrunk, will not shrink again.
+--
+-- Minimal value is the first shrunk value, if it exists, and the original
+-- otherwise.
+shrinkToOneOf :: forall a. a -> [a] -> Gen a
+shrinkToOneOf x xs =
     aux <$> primWith shrinker
   where
     aux :: Sample -> a
     aux (NotShrunk _) = x
-    aux (Shrunk    i) = xs !! fromIntegral i
+    aux (Shrunk    i) = index i xs
 
+    -- When we shrink, we will try a bunch of new sample trees; we must ensure
+    -- that we can try /any/ of the possible shrunk values.
+    --
+    -- We use this to implement 'fromShrinkTree'. Here, we explore a rose tree
+    -- of possibilities; at every level in the tree, once we make a choice,
+    -- we should commit to that choice and not consider it over and over again.
+    -- Thus, once shrunk, we should not shrink any further.
     shrinker :: Sample -> [Word64]
     shrinker (Shrunk _)    = []
-    shrinker (NotShrunk _)
-               | null xs   = []
-               | otherwise = [0 .. fromIntegral (length xs) - 1]
+    shrinker (NotShrunk _) = zipWith const [0..] xs
+
+    -- Index the list of possible shrunk values. This is a bit like @(!!)@ from
+    -- the prelude, but with some edge cases.
+    --
+    -- - If the list is empty, we return the unshrunk value.
+    -- - Otherwise, if the index exceeds the bounds, we return the last element.
+    --
+    -- These two special cases can arise in one of two circumstances:
+    --
+    -- - When we run the generator against the 'Minimal' tree. This will give us
+    --   a @Shrunk 0@ value, independent of what the specified shrinking
+    --   function does, and it is important that we produce the right value.
+    -- - When the generator is run against a sample tree that was shrunk wrt to
+    --   a /different/ generator. In this case the value could be anything;
+    --   we return the final ("least preferred") element, and then rely on
+    --   later shrinking to replace this with a more preferred element.
+    index :: Word64 -> [a] -> a
+    index _ []     = x
+    index _ [y]    = y
+    index 0 (y:_)  = y
+    index n (_:ys) = index (n - 1) ys
 
 -- | Generator that always produces @x@ as initial value, and shrinks to @y@
 firstThen :: forall a. a -> a -> Gen a
-firstThen x y = x `shrinkTo` [y]
+firstThen x y = x `shrinkToOneOf` [y]
 
 -- | Shrink with provided shrinker
 --
@@ -205,13 +234,26 @@ firstThen x y = x `shrinkTo` [y]
 -- the property is not reevaluated at already-shrunk values.
 shrinkWith :: forall a. (a -> [a]) -> Gen a -> Gen a
 shrinkWith f gen = do
+    -- It is critical that we do not apply normal shrinking of the 'SampleTree'
+    -- here (not even to 'Minimal'). If we did, then the resulting shrink tree
+    -- would change, and we would be unable to iteratively construct a path
+    -- through the shrink tree.
+    --
+    -- Of course, it can still happen that the generator gets reapplied in a
+    -- different context; we must take this case into account in 'shrinkTo'.
     x <- withoutShrinking gen
-    go $ Rose.unfoldTree (\x' -> (x', f x')) x
+    fromShrinkTree $ Rose.unfoldTree (\x' -> (x', f x')) x
+
+{-------------------------------------------------------------------------------
+  Shrink trees
+-------------------------------------------------------------------------------}
+
+fromShrinkTree :: forall a. Rose.Tree a -> Gen a
+fromShrinkTree = go
   where
     go :: Rose.Tree a -> Gen a
-    go (Rose.Node x []) = return x
     go (Rose.Node x xs) = do
-        next <- Nothing `shrinkTo` map Just xs
+        next <- Nothing `shrinkToOneOf` map Just xs
         case next of
           Nothing -> return x
           Just x' -> go x'

--- a/src/Test/Falsify/Internal/Generator/Definition.hs
+++ b/src/Test/Falsify/Internal/Generator/Definition.hs
@@ -123,10 +123,10 @@ instance Monad Gen where
 
 -- | Disable shrinking in the given generator
 --
--- This should be considered a hint only: in particular, values may /always/ be
--- shrunk to their minimum value, and if the structure of a generator changes
--- and random samples are interpreted in a different context, we might "shrink"
--- from any value to another other value (including even larger values).
+-- Due to the nature of internal shrinking, it is always possible that a
+-- generator gets reapplied to samples that were shrunk wrt to a /different/
+-- generator. In this sense, 'withoutShrinking' should be considered to be a
+-- hint only.
 --
 -- This function is only occassionally necessary; most users will probably not
 -- need to use it.

--- a/src/Test/Falsify/Internal/Generator/ShrinkStep.hs
+++ b/src/Test/Falsify/Internal/Generator/ShrinkStep.hs
@@ -1,0 +1,137 @@
+-- | A single shrink step
+--
+-- Intended for qualified import.
+--
+-- import Test.Falsify.Internal.Generator.ShrinkStep (Step)
+-- import qualified Test.Falsify.Internal.Generator.ShrinkStep as Step
+
+module Test.Falsify.Internal.Generator.ShrinkStep (
+    Step -- opaque
+  , step
+    -- * Working with the 'SampleTree'
+  , next
+  , left
+  , right
+    -- * Shrink the 'SampleTree'
+  , Shortcut
+  , shortcutMinimal
+  , sampleTree
+  ) where
+
+import Data.Bifunctor
+import Data.Functor
+import Data.Word
+
+import Test.Falsify.Internal.Generator.Definition
+import Test.Falsify.SampleTree (SampleTree(..), Sample(..))
+
+import qualified Test.Falsify.SampleTree as SampleTree
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | A single step during shrinking
+--
+-- We separately record ways in which the value can be shrunk that is
+-- independent of the 'SampleTree'.
+newtype Step a = Step { step :: SampleTree -> [(a, SampleTree)] }
+  deriving (Functor, Semigroup, Monoid)
+
+{-------------------------------------------------------------------------------
+  Stepping parts of the sample tree
+-------------------------------------------------------------------------------}
+
+-- | Shrink the next sample
+next :: (Sample -> [Word64]) -> Step Sample
+next f = Step $ \case
+    Minimal          -> []
+    SampleTree s l r -> f s <&> \s' -> (Shrunk s', SampleTree (Shrunk s') l r)
+
+-- | Apply a step at the left subtree
+left :: Step a -> Step a
+left (Step f) = Step $ \case
+    Minimal          -> []
+    SampleTree s l r -> f l <&> \(a, l') -> (a, SampleTree s l' r)
+
+-- | Apply a step at the right subtree
+right :: Step a -> Step a
+right (Step f) = Step $ \case
+    Minimal          -> []
+    SampleTree s l r -> f r <&> \(a, r') -> (a, SampleTree s l r')
+
+{-------------------------------------------------------------------------------
+  Shrinking the 'SampleTree', guided by a generator
+
+  This could be considered to be the core of the @falsify@ approach.
+-------------------------------------------------------------------------------}
+
+-- | Shortcut shrinking
+--
+-- A shortcut is a way to shrink "faster" than the normal generator-driven
+-- shrinker would shrink. It is given the shrunk sample trees that regular
+-- shrinking would compute, and it can modify this list as it sees fit. The
+-- identity function is a valid shortcut, but only in the absence of infinite
+-- generators (see 'shortcutMinimal').
+type Shortcut = forall a. Gen a -> Step a -> Step a
+
+-- | Introduce the 'Minimal' sample tree at any point
+--
+-- It is important to introduce 'Minimal' when dealing with infinite generators:
+-- since these look at an infinite portion of the sample tree. It is important
+-- that we cut off this portion by introducing 'Minimal' at some point, to
+-- ensure that shrinking terminates. The precise point of /where/ we introduce
+-- 'Minimal' will depend on the property being tested: on the condition that
+-- that property only depends on a finite part of the generated value, there
+-- /must/ be a part of the sample tree that is not relevant and hence can
+-- successfully be replaced by 'Minimal' without affecting what is being tested.
+--
+-- It is /also/ important that we /only/ introduce 'Minimal' if we can shrink
+-- at /all/. This guarantees that we respect 'withoutShrinking' annotations;
+-- see 'shrinkWith' for additional discussion.
+shortcutMinimal :: Shortcut
+shortcutMinimal gen (Step f) = Step $ \st ->
+    case f st of
+      []     -> []
+      shrunk -> (run gen Minimal, Minimal) : shrunk
+
+-- | Shrinking the 'SampleTree', guided by a generator
+--
+-- This is not quite as clean as in the paper, because it does two things at
+-- once: shrink the sample tree /and/ run the generator. This results in better
+-- performance (we need the results of execution /anyway/ in the definitions for
+-- 'Bind' and 'Select'), and ultimately cleaner code overall (at call sites).
+sampleTree :: Shortcut -> Gen a -> Step a
+sampleTree shortcut = go
+  where
+    -- Apply the shortcut at any point in the tree
+    go :: Gen a -> Step a
+    go gen = shortcut gen $ go' gen
+
+    go' :: Gen a -> Step a
+
+    -- The generator is independent of the tree: /no point/ shrinking
+    go' (Pure _) = mempty
+
+    -- Actual shrinking only happens for the primitive generator
+    -- We cannot shrink if the value is already minimal.
+    go' (Prim (P f g)) = g <$> next f
+
+    -- For 'Bind' we shrink either the left or the right tree.
+    -- As is usual, this introduces a left bias.
+    go' (Bind x f) = Step $ \st -> concat [
+          first (\a -> run (f a) (SampleTree.right st)) <$>
+            step (left (go x)) st
+        , let a = run x (SampleTree.left st)
+          in step (right (go (f a))) st
+        ]
+
+    -- The case for 'Select' is similar except that that we shrink the right
+    -- subtree /only/ if it used: this is the raison d'être of 'Select'.
+    go' (Select e f) = Step $ \st -> concat [
+          first (either (run f (SampleTree.right st)) id) <$>
+            step (left (go e)) st
+        , case run e (SampleTree.left st) of
+            Left  a -> first ($ a) <$> step (right (go f)) st
+            Right _ -> []
+        ]

--- a/test/TestSuite/Sanity/Selective.hs
+++ b/test/TestSuite/Sanity/Selective.hs
@@ -163,7 +163,11 @@ test_tree_ifBoth = do
         run (tree ifBoth depth) (sampleTree depth)
     didTimeout <- timeout 10_000_000 $ assertBool "shrunk" $
       all isBiased $
-        shrinkWithShortcut id (const True) (tree ifBoth depth) (sampleTree depth)
+        shrinkWithShortcut
+          (const id)
+          (const True)
+          (tree ifBoth depth)
+          (sampleTree depth)
     case didTimeout of
       Just () -> assertFailure "Expected timeout, but did not get it"
       Nothing -> return "Timed out as expected"
@@ -179,7 +183,11 @@ test_tree_ifS depth = do
         run (tree ifS depth) (sampleTree depth)
     assertBool "shrunk" $
       all isBiased $
-        shrinkWithShortcut id (const True) (tree ifS depth) (sampleTree depth)
+        shrinkWithShortcut
+          (const id)
+          (const True)
+          (tree ifS depth)
+          (sampleTree depth)
   where
     -- We reuse the depth as a seed
     sampleTree :: Word64 -> SampleTree


### PR DESCRIPTION
This also fixes `shrinkTo` (now `shrinkToOneOf`); see inline comments.