### PR TITLE
Generate and shrink functions

### DIFF
--- a/falsify.cabal
+++ b/falsify.cabal
@@ -38,25 +38,32 @@ common lang
   default-language:
       Haskell2010
   default-extensions:
+      DefaultSignatures
+      DeriveAnyClass
       DeriveFoldable
       DeriveFunctor
       DeriveGeneric
       DeriveTraversable
       DerivingStrategies
+      DerivingVia
       DisambiguateRecordFields
+      FlexibleContexts
       FlexibleInstances
       GADTs
       GeneralizedNewtypeDeriving
+      KindSignatures
       LambdaCase
       MultiParamTypeClasses
       NamedFieldPuns
       NumericUnderscores
       PatternSynonyms
+      QuantifiedConstraints
       RankNTypes
       ScopedTypeVariables
       StandaloneDeriving
       TupleSections
       TypeApplications
+      TypeOperators
       ViewPatterns
 
 library
@@ -91,6 +98,9 @@ library
       Test.Falsify.Internal.Search
       Test.Falsify.Internal.Tasty
       Test.Falsify.Reexported.Generator.Compound
+      Test.Falsify.Reexported.Generator.Function
+      Test.Falsify.Reexported.Generator.Function.Perturb
+      Test.Falsify.Reexported.Generator.Function.Reified
       Test.Falsify.Reexported.Generator.Simple
   hs-source-dirs:
       src
@@ -121,6 +131,7 @@ test-suite test-falsify
   other-modules:
       TestSuite.Sanity.Auxiliary
       TestSuite.Sanity.Compound
+      TestSuite.Sanity.Functions
       TestSuite.Sanity.Prim
       TestSuite.Sanity.Range
       TestSuite.Sanity.Selective

--- a/src/Test/Falsify/Generator.hs
+++ b/src/Test/Falsify/Generator.hs
@@ -16,6 +16,12 @@ module Test.Falsify.Generator (
   , either
   , list
   , tree
+    -- ** Functions
+  , Fun
+  , pattern Fn
+  , pattern Fn2
+  , pattern Fn3
+  , fun
     -- ** User-specified shrinking
   , shrinkToOneOf
   , firstThen
@@ -37,4 +43,5 @@ import Prelude hiding (either)
 import Test.Falsify.Generator.Auxiliary
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Reexported.Generator.Compound
+import Test.Falsify.Reexported.Generator.Function
 import Test.Falsify.Reexported.Generator.Simple

--- a/src/Test/Falsify/Reexported/Generator/Function.hs
+++ b/src/Test/Falsify/Reexported/Generator/Function.hs
@@ -1,0 +1,181 @@
+module Test.Falsify.Reexported.Generator.Function (
+    Fun -- opaque
+  , pattern Fn
+  , pattern Fn2
+  , pattern Fn3
+  , fun
+  ) where
+
+import qualified Data.Tree as Rose
+
+import Test.Falsify.Generator.Auxiliary
+import Test.Falsify.Internal.Generator
+import Test.Falsify.Internal.Generator.ShrinkStep (Step)
+import Test.Falsify.Reexported.Generator.Function.Perturb
+import Test.Falsify.Reexported.Generator.Function.Reified
+import Test.Falsify.SampleTree (SampleTree)
+
+import qualified Test.Falsify.Internal.Generator.ShrinkStep as Step
+
+{-------------------------------------------------------------------------------
+  Functions that can be shrunk and shown
+
+  This is the public facing API.
+-------------------------------------------------------------------------------}
+
+data Fun a b = Fun (a :-> b, b, IsFullyShrunk) (a -> b)
+  deriving (Functor)
+
+instance (Show a, Show b) => Show (Fun a b) where
+  show (Fun (_, _, NotFullyShrunk) _) = "<fun>"
+  show (Fun (p, d, FullyShrunk)    _) = showFunction p (Just d)
+
+-- | Internal marker: has the function been fully shrunk?
+--
+-- Since functions are typically infinite, they can only safely be shown once
+-- they are fully shrunk: after all, once a function has been fully shrunk,
+-- we /know/ it must be finite, because in any given property, a function will
+-- only ever be applied a finite number of times.
+data IsFullyShrunk = FullyShrunk | NotFullyShrunk
+
+{-------------------------------------------------------------------------------
+  Patterns
+
+  These are analogue to their counterparts in QuickCheck.
+-------------------------------------------------------------------------------}
+
+pattern Fn :: (a -> b) -> Fun a b
+pattern Fn f <- (applyFun -> f)
+
+pattern Fn2 :: (a -> b -> c) -> Fun (a, b) c
+pattern Fn2 f <- (applyFun2 -> f)
+
+pattern Fn3 :: (a -> b -> c -> d) -> Fun (a, b, c) d
+pattern Fn3 f <- (applyFun3 -> f)
+
+applyFun :: Fun a b -> (a -> b)
+applyFun (Fun _ f) = f
+
+applyFun2 :: Fun (a, b) c -> (a -> b -> c)
+applyFun2 f a b = applyFun f (a, b)
+
+applyFun3 :: Fun (a, b, c) d -> (a -> b -> c -> d)
+applyFun3 f a b c = applyFun f (a, b, c)
+
+{-# COMPLETE Fn  #-}
+{-# COMPLETE Fn2 #-}
+{-# COMPLETE Fn3 #-}
+
+{-------------------------------------------------------------------------------
+  Generation
+-------------------------------------------------------------------------------}
+
+fun :: forall a b. (Function a, Perturb a) => Gen b -> Gen (Fun a b)
+fun gen = do
+    def <- gen
+    st  <- captureLocalTree (const [])
+
+    let f :: a -> b
+        f a = run gen $ getAtFocus (perturb a) st
+
+    uncurry (aux def) <$> fromShrinkTree (shrinkTreeReified gen st (function f))
+  where
+    aux :: b -> IsFullyShrunk -> (a :-> b) -> Fun a b
+    aux def isFullyShrunk reified =
+        Fun (reified, def, isFullyShrunk)
+            (abstract reified def)
+
+-- | Shrink reified function
+--
+-- Also returns whether the function has been fully shrunk. Like QuickCheck, we
+-- rely on shrinking order to set this flag.
+shrinkTreeReified :: forall a b.
+     Gen b
+  -> SampleTree
+  -> (a :-> b) -> Rose.Tree (IsFullyShrunk, a :-> b)
+shrinkTreeReified gen = \st f ->
+    markFullyShrunk $ Rose.unfoldTree aux (f, st)
+  where
+    aux :: (a :-> b, SampleTree) -> (a :-> b, [(a :-> b, SampleTree)])
+    aux (f, st) = (f, Step.step (shrinkReified stepGen f) st)
+
+    -- We do not need the old value generated in order to shrink it: regular
+    -- shrinking does not proceed by looking at previous values, but rather by
+    -- re-running the generator on a shrunk sample tree.
+    stepGen :: b -> Step b
+    stepGen _ = Step.sampleTree Step.shortcutMinimal gen
+
+    -- Add new leaves into the tree that mark the function as fully shrunk
+    markFullyShrunk :: Rose.Tree (a :-> b) -> Rose.Tree (IsFullyShrunk, a :-> b)
+    markFullyShrunk (Rose.Node f fs) =
+        Rose.Node (NotFullyShrunk, f) $ concat [
+            map markFullyShrunk fs
+          , [Rose.Node (FullyShrunk, f) []]
+          ]
+
+{-------------------------------------------------------------------------------
+  Shrinking reified functions
+-------------------------------------------------------------------------------}
+
+-- | Shrink a pair @(a, b)@ belonging to the graph of a function
+shrinkFnPair :: forall a b. Perturb a => (b -> Step b) -> (a, b) -> Step (a, b)
+shrinkFnPair step (a, b) = (a,) <$> stepAtFocus (perturb a) (step b)
+
+-- | Shrink a reified function
+--
+-- This is the centrepiece of this whole module. We follow a similar strategy
+-- as QuickCheck does, but the details are different. In particular, the
+-- QuickCheck version depends on a shrinker for the result of the function,
+-- which of course we not have: we must shrink sample trees instead.
+shrinkReified :: forall a c. (c -> Step c) -> (a :-> c) -> Step (a :-> c)
+shrinkReified step = go
+  where
+    -- When we generate a reified function it will typically be infinitely
+    -- large. It is therefore critical that we can replace entire chunks of the
+    -- concrete function with 'Nil', so that shrinking will terminate (this is
+    -- very similar to replacing entire parts of the sample tree with Minimal).
+    go :: forall x. (x :-> c) -> Step (x :-> c)
+    go Nil = go' Nil
+    go f   = go' f `Step.butPrefer` [Nil]
+
+    go' :: forall x. (x :-> c) -> Step (x :-> c)
+    go' Nil         = mempty
+    go' (Unit c)    = Unit      <$> step c
+    go' (Map f g p) = mkMap f g <$> go p
+    go' (Prod f)    = mkProd    <$> shrinkReified go f
+    go' (Sum f g)   = mconcat [
+                          (\f' -> mkSum f' g ) <$> go f
+                        , (\g' -> mkSum f  g') <$> go g
+                        ]
+    go' (Table xys) = mkTable   <$> (   Step.one (shrinkFnPair step) xys
+                                      `Step.butPrefer`
+                                        removeSome xys
+                                    )
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: sample-tree independent shrinking
+
+  This is adapted from code in QuickCheck.
+-------------------------------------------------------------------------------}
+
+removeSome :: [a] -> [[a]]
+removeSome xs = concat [
+     removeChunkOfSize k xs
+   | k <- takeWhile (> 0) (iterate (`div` 2) n)
+   ]
+ where
+   n = length xs
+
+-- | All ways to remove @k@ consecutive elements from a list
+--
+-- Unlike in 'QuickCheck, we prefer to remove elements from the /end/ of the
+-- list. For the case of function tables, this means that we prefer to keep
+-- entries in the table for smaller values.
+removeChunkOfSize :: Int -> [a] -> [[a]]
+removeChunkOfSize k = reverse . go
+  where
+    go :: [a] -> [[a]]
+    go [] = []
+    go xs = xs2 : map (xs1 ++) (go xs2)
+      where
+        (xs1, xs2) = splitAt k xs

--- a/src/Test/Falsify/Reexported/Generator/Function/Perturb.hs
+++ b/src/Test/Falsify/Reexported/Generator/Function/Perturb.hs
@@ -1,0 +1,208 @@
+module Test.Falsify.Reexported.Generator.Function.Perturb (
+    -- * Focs
+    Focus(..)
+  , variant
+    -- * Internal utilities
+  , getAtFocus
+  , stepAtFocus
+   -- * Perturb
+  , Perturb(..)
+  ) where
+
+import Data.Int
+import Data.Ratio (Ratio)
+import Data.Word
+import GHC.Generics
+import Numeric.Natural
+
+import qualified Data.Ratio as Ratio
+
+import Test.Falsify.SampleTree (SampleTree(..))
+import Test.Falsify.Internal.Generator.ShrinkStep (Step)
+
+import qualified Test.Falsify.Internal.Generator.ShrinkStep as Step
+import qualified Test.Falsify.SampleTree                    as SampleTree
+
+{-------------------------------------------------------------------------------
+  Focus
+-------------------------------------------------------------------------------}
+
+data Focus = FocusHere | FocusLeft Focus | FocusRight Focus
+
+instance Semigroup Focus where
+  FocusHere    <> f' = f'
+  FocusLeft  f <> f' = FocusLeft  (f <> f')
+  FocusRight f <> f' = FocusRight (f <> f')
+
+instance Monoid Focus where
+  mempty = FocusHere
+
+variant :: Integer -> Focus
+variant 0 = FocusLeft FocusHere
+variant n = FocusRight $ variant (n - 1)
+
+{-------------------------------------------------------------------------------
+  Using 'Focus'
+
+  This does not need to be part of the publicly exported API.
+-------------------------------------------------------------------------------}
+
+getAtFocus :: Focus -> SampleTree -> SampleTree
+getAtFocus = go
+  where
+    go :: Focus -> SampleTree -> SampleTree
+    go FocusHere      = id
+    go (FocusLeft  f) = go f . SampleTree.left
+    go (FocusRight f) = go f . SampleTree.right
+
+stepAtFocus :: Focus -> Step a -> Step a
+stepAtFocus = go
+  where
+    go :: Focus -> Step a -> Step a
+    go FocusHere      = id
+    go (FocusLeft  f) = Step.left  . go f
+    go (FocusRight f) = Step.right . go f
+
+{-------------------------------------------------------------------------------
+  Perturbations
+-------------------------------------------------------------------------------}
+
+class Perturb a where
+  perturb :: a -> Focus
+
+  default perturb :: (Generic a, GPerturb (Rep a)) => a -> Focus
+  perturb = gPerturb . from
+
+-- Instances that rely on deriving-via
+
+deriving via AsEnum Bool     instance Perturb Bool
+deriving via AsEnum Char     instance Perturb Char
+deriving via AsEnum Ordering instance Perturb Ordering
+
+deriving via AsIntegral Int     instance Perturb Int
+deriving via AsIntegral Int8    instance Perturb Int8
+deriving via AsIntegral Int16   instance Perturb Int16
+deriving via AsIntegral Int32   instance Perturb Int32
+deriving via AsIntegral Int64   instance Perturb Int64
+deriving via AsIntegral Word    instance Perturb Word
+deriving via AsIntegral Word8   instance Perturb Word8
+deriving via AsIntegral Word16  instance Perturb Word16
+deriving via AsIntegral Word32  instance Perturb Word32
+deriving via AsIntegral Word64  instance Perturb Word64
+deriving via AsIntegral Integer instance Perturb Integer
+deriving via AsIntegral Natural instance Perturb Natural
+
+deriving via AsReal Float  instance Perturb Float
+deriving via AsReal Double instance Perturb Double
+
+-- Instances that rely on generics
+
+instance Perturb ()
+instance Perturb a => Perturb [a]
+instance (Perturb a, Perturb b) => Perturb (Either a b)
+
+-- Tuples (also relies on generics)
+--
+-- We don't provide instances for larger than 7; this is an arbitrary of course,
+-- but happens to match the limit for tuples that have a Generics instance.
+
+-- 2
+instance
+     ( Perturb a
+     , Perturb b
+     )
+  => Perturb (a, b)
+
+-- 3
+instance
+     ( Perturb a
+     , Perturb b
+     , Perturb c
+     )
+  => Perturb (a, b, c)
+
+-- 4
+instance
+     ( Perturb a
+     , Perturb b
+     , Perturb c
+     , Perturb d
+     )
+  => Perturb (a, b, c, d)
+
+-- 5
+instance
+     ( Perturb a
+     , Perturb b
+     , Perturb c
+     , Perturb d
+     , Perturb e
+     )
+  => Perturb (a, b, c, d, e)
+
+-- 6
+instance
+     ( Perturb a
+     , Perturb b
+     , Perturb c
+     , Perturb d
+     , Perturb e
+     , Perturb f
+     )
+  => Perturb (a, b, c, d, e, f)
+
+-- 7
+instance
+     ( Perturb a
+     , Perturb b
+     , Perturb c
+     , Perturb d
+     , Perturb e
+     , Perturb f
+     , Perturb g
+     )
+  => Perturb (a, b, c, d, e, f, g)
+
+{-------------------------------------------------------------------------------
+  Generic support for 'Perturb'
+-------------------------------------------------------------------------------}
+
+class GPerturb f where
+  gPerturb :: f a -> Focus
+
+instance GPerturb f => GPerturb (M1 i c f) where
+  gPerturb = gPerturb . unM1
+
+instance GPerturb U1 where
+  gPerturb U1 = FocusHere
+
+instance (GPerturb f, GPerturb g) => GPerturb (f :*: g) where
+  gPerturb (x :*: y) = gPerturb x <> gPerturb y
+
+instance (GPerturb f, GPerturb g) => GPerturb (f :+: g) where
+  gPerturb (L1 x) = variant 0 <> gPerturb x
+  gPerturb (R1 y) = variant 1 <> gPerturb y
+
+instance Perturb c => GPerturb (K1 i c) where
+  gPerturb (K1 c) = perturb c
+
+{-------------------------------------------------------------------------------
+  Deriving-via support for 'Perturb'
+-------------------------------------------------------------------------------}
+
+newtype AsIntegral a = WrapAsIntegral a
+newtype AsEnum     a = WrapAsEnum     a
+newtype AsReal     a = WrapAsReal     a
+
+instance Integral a => Perturb (AsIntegral a) where
+  perturb (WrapAsIntegral x) = variant $ toInteger x
+
+instance Enum a => Perturb (AsEnum a) where
+  perturb (WrapAsEnum x) = variant $ fromIntegral (fromEnum x)
+
+instance Real a => Perturb (AsReal a) where
+  perturb (WrapAsReal x) =
+      perturb (Ratio.numerator r, Ratio.denominator r)
+    where
+      r :: Ratio Integer
+      r = toRational x

--- a/src/Test/Falsify/Reexported/Generator/Function/Reified.hs
+++ b/src/Test/Falsify/Reexported/Generator/Function/Reified.hs
@@ -1,0 +1,364 @@
+module Test.Falsify.Reexported.Generator.Function.Reified (
+    -- * Reified functions
+    (:->)(..)
+  , abstract
+  , showFunction
+    -- ** Smart constructors
+  , mkProd
+  , mkSum
+  , mkTable
+  , mkMap
+    -- * Construction
+  , Function(..)
+  , functionMap
+  , functionMapWith
+  ) where
+
+import Data.Bifunctor
+import Data.Char
+import Data.Int
+import Data.List (intersperse)
+import Data.Ratio (Ratio)
+import Data.Word
+import GHC.Generics
+import Numeric.Natural
+
+import qualified Data.Ratio as Ratio
+
+import Test.Falsify.Reexported.Generator.Function.Perturb
+
+{-------------------------------------------------------------------------------
+  Reified functions
+
+  This is adapted from code in in QuickCheck.
+-------------------------------------------------------------------------------}
+
+-- | Reified functions
+--
+-- The constructors of this type are not exported.
+data a :-> c where
+  Nil   :: a :-> c
+  Unit  :: c -> (() :-> c)
+  Prod  :: (a :-> (b :-> c)) -> ((a, b) :-> c)
+  Sum   :: (a :-> c) -> (b :-> c) -> (Either a b :-> c)
+  Table :: (Eq a, Perturb a) => [(a, c)] -> (a :-> c)
+  Map   :: (a -> b) -> (b -> a) -> (b :-> c) -> (a :-> c)
+
+instance Functor ((:->) a) where
+  fmap _ Nil           = Nil
+  fmap f (Unit c)      = Unit (f c)
+  fmap f (Prod p)      = Prod (fmap (fmap f) p)
+  fmap f (Sum p q)     = Sum (fmap f p) (fmap f q)
+  fmap f (Table xys)   = Table $ map (second f) xys
+  fmap f (Map ab ba p) = Map ab ba (fmap f p)
+
+-- | Turn concrete function into an abstract function (with a default result)
+abstract :: (a :-> c) -> c -> (a -> c)
+abstract (Prod p)    d (x,y) = abstract (fmap (\q -> abstract q d y) p) d x
+abstract (Sum p q)   d exy   = either (abstract p d) (abstract q d) exy
+abstract (Unit c)    _ _     = c
+abstract Nil         d _     = d
+abstract (Table xys) d x     = head ([y | (x',y) <- xys, x == x'] ++ [d])
+abstract (Map g _ p) d x     = abstract p d (g x)
+
+{-------------------------------------------------------------------------------
+  Show
+-------------------------------------------------------------------------------}
+
+instance (Show a, Show b) => Show (a :-> b) where
+  show p = showFunction p Nothing
+
+-- | Show reified function
+--
+-- Only use this on finite functions.
+showFunction :: (Show a, Show b) => (a :-> b) -> Maybe b -> String
+showFunction p md = concat [
+      "{"
+    , concat . intersperse ", " $ concat [
+          [ show x ++ "->" ++ show c
+          | (x,c) <- table p
+          ]
+        , [ "_->" ++ show d
+          | Just d <- [md]
+          ]
+        ]
+    , "}"
+    ]
+
+-- | Generating a table from a concrete function
+--
+-- This is only used in the 'Show' instance.
+table :: (a :-> c) -> [(a,c)]
+table (Prod p)    = [ ((x,y),c) | (x,q) <- table p, (y,c) <- table q ]
+table (Sum p q)   = [ (Left x, c) | (x,c) <- table p ]
+                 ++ [ (Right y,c) | (y,c) <- table q ]
+table (Unit c)    = [ ((), c) ]
+table Nil         = []
+table (Table xys) = xys
+table (Map _ h p) = [ (h x, c) | (x,c) <- table p ]
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: smart constructors
+-------------------------------------------------------------------------------}
+
+mkProd :: (a :-> (b :-> c)) -> (a, b) :-> c
+mkProd Nil = Nil
+mkProd p   = Prod p
+
+mkSum :: (a :-> c) -> (b :-> c) -> Either a b :-> c
+mkSum Nil Nil = Nil
+mkSum p   q   = Sum p q
+
+mkTable :: (Eq a, Perturb a) => [(a, c)] -> a :-> c
+mkTable []  = Nil
+mkTable xys = Table xys
+
+mkMap :: (a -> b) -> (b -> a) -> (b :-> c) -> a :-> c
+mkMap _ _ Nil = Nil
+mkMap f g p   = Map f g p
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | Functions that can be reified
+--
+-- This is analogue to the class of the same name in 'QuickCheck', but our
+-- definition of reified functions (@:->@) is different.
+class Function a where
+  function :: (a -> b) -> (a :-> b)
+
+  default function :: (Generic a, GFunction (Rep a)) => (a -> b) -> (a :-> b)
+  function = genericFunction
+
+-- "Primitive" instances
+
+instance Function Int8  where function = functionBoundedEnum
+instance Function Word8 where function = functionBoundedEnum
+
+instance Function Int     where function = functionIntegral
+instance Function Int16   where function = functionIntegral
+instance Function Int32   where function = functionIntegral
+instance Function Int64   where function = functionIntegral
+instance Function Word    where function = functionIntegral
+instance Function Word16  where function = functionIntegral
+instance Function Word32  where function = functionIntegral
+instance Function Word64  where function = functionIntegral
+instance Function Integer where function = functionIntegral
+instance Function Natural where function = functionIntegral
+
+instance Function Float  where function = functionRealFrac
+instance Function Double where function = functionRealFrac
+
+-- Derived instances
+
+instance Function Char where
+  function = functionMap ord chr
+
+instance (Integral a, Function a) => Function (Ratio a) where
+  function = functionMap toPair fromPair
+    where
+      toPair :: Ratio a -> (a, a)
+      toPair r = (Ratio.numerator r, Ratio.denominator r)
+
+      fromPair :: (a, a) -> Ratio a
+      fromPair (n, d) = n Ratio.% d
+
+-- Instances that depend on generics
+
+instance Function ()
+instance Function Bool
+instance (Function a, Function b) => Function (Either a b)
+instance Function a => Function [a]
+instance Function a => Function (Maybe a)
+
+-- Tuples (these are also using generics)
+
+-- 2
+instance
+     ( Function a
+     , Function b
+     )
+  => Function (a, b)
+
+-- 3
+instance
+     ( Function a
+     , Function b
+     , Function c
+     )
+  => Function (a, b, c)
+
+-- 4
+instance
+     ( Function a
+     , Function b
+     , Function c
+     , Function d
+     )
+  => Function (a, b, c, d)
+
+-- 5
+instance
+     ( Function a
+     , Function b
+     , Function c
+     , Function d
+     , Function e
+     )
+  => Function (a, b, c, d, e)
+
+-- 6
+instance
+     ( Function a
+     , Function b
+     , Function c
+     , Function d
+     , Function e
+     , Function f
+     )
+  => Function (a, b, c, d, e, f)
+
+-- 7
+instance
+     ( Function a
+     , Function b
+     , Function c
+     , Function d
+     , Function e
+     , Function f
+     , Function g
+     )
+  => Function (a, b, c, d, e, f, g)
+
+{-------------------------------------------------------------------------------
+  Additional constructors for 'Map'
+-------------------------------------------------------------------------------}
+
+-- | The basic building block for 'Function' instances
+--
+-- Provides a 'Function' instance by mapping to and from a type that
+-- already has a 'Function' instance.
+functionMap ::
+     Function b
+  => (a -> b) -> (b -> a) -> (a -> c) -> (a :-> c)
+functionMap ab ba = functionMapWith ab ba function
+
+-- | Convenience function for constructiong 'Map'
+functionMapWith ::
+     (a -> b)
+  -> (b -> a)
+  -> ((b -> c) -> (b :-> c))
+  -> ((a -> c) -> (a :-> c))
+functionMapWith ab ba f = mkMap ab ba . (f .  (. ba))
+
+{-------------------------------------------------------------------------------
+  Auxiliary functions for constructing 'Function' instances
+
+  We cannot use deriving-via here because the role of the first parameter to
+  @:->@ is nominal (due to to the constraints imposed by 'Table').
+-------------------------------------------------------------------------------}
+
+functionBoundedEnum ::
+     (Eq a, Perturb a, Enum a, Bounded a)
+  => (a -> b) -> a :-> b
+functionBoundedEnum f = Table $ [ (x, f x) | x <- [minBound .. maxBound] ]
+
+functionIntegral :: Integral a => (a -> b) -> a :-> b
+functionIntegral =
+    functionMap
+      (fmap bytes  . toSignedNatural   . toInteger)
+      (fromInteger . fromSignedNatural . fmap unbytes)
+  where
+    bytes :: Natural -> [Word8]
+    bytes 0 = []
+    bytes n = fromIntegral (n `mod` 256) : bytes (n `div` 256)
+
+    unbytes :: [Word8] -> Natural
+    unbytes []     = 0
+    unbytes (w:ws) = fromIntegral w + 256 * unbytes ws
+
+functionRealFrac :: RealFrac a => (a -> b) -> (a :-> b)
+functionRealFrac = functionMap toRational fromRational
+
+{-------------------------------------------------------------------------------
+  Generic support for 'Function'
+-------------------------------------------------------------------------------}
+
+-- | Generic 'Function' implementation.
+genericFunction :: (Generic a, GFunction (Rep a)) => (a -> b) -> (a :-> b)
+genericFunction = functionMapWith from to gFunction
+
+class GFunction f where
+  gFunction :: (f a -> b) -> (f a :-> b)
+
+instance GFunction f => GFunction (M1 i c f) where
+  gFunction = functionMapWith unM1 M1 gFunction
+
+instance GFunction U1 where
+  gFunction = functionMapWith unwrap wrap $ \f ->
+      Unit $ f ()
+    where
+      unwrap :: U1 p -> ()
+      unwrap _ = ()
+
+      wrap :: () -> U1 p
+      wrap _ = U1
+
+instance (GFunction f, GFunction g) => GFunction (f :*: g) where
+  gFunction = functionMapWith unwrap wrap $ \f ->
+      mkProd $ gFunction <$> gFunction (curry f)
+    where
+      unwrap :: (f :*: g) p -> (f p, g p)
+      unwrap (x :*: y) = (x, y)
+
+      wrap :: (f p, g p) -> (f :*: g) p
+      wrap (x, y) = x :*: y
+
+instance (GFunction f, GFunction g) => GFunction (f :+: g) where
+  gFunction = functionMapWith unwrap wrap $ \f ->
+      mkSum (gFunction (f . Left)) (gFunction (f . Right))
+    where
+      unwrap :: (f :+: g) p -> Either (f p) (g p)
+      unwrap (L1 x) = Left  x
+      unwrap (R1 y) = Right y
+
+      wrap :: Either (f p) (g p) -> (f :+: g) p
+      wrap (Left  x) = L1 x
+      wrap (Right y) = R1 y
+
+instance Function a => GFunction (K1 i a) where
+  gFunction = functionMap unK1 K1
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: dealing with signed numbers
+
+  Lemma:
+
+  > forall n, fromSignedNatural (toSignedNatural n) == n
+
+  Proof: case split on whether @n@ is negative or positive. If negative:
+
+  >    fromSignedNatural (toSignedNatural n)
+  > == fromSignedNatural (Neg (fromInteger (abs n - 1)))
+  > == negate (toInteger (fromInteger (abs n - 1)) + 1)
+  > == negate (abs n - 1 + 1)
+  > == negate (abs n)
+  > == n (if n negative)
+
+  The case for positive is similar, but easier.
+  -----------------------------------------------------------------------------}
+
+data Signed a = Pos a | Neg a
+  deriving stock (Show, Functor, Generic)
+  deriving anyclass (Function)
+
+toSignedNatural :: Integer -> Signed Natural
+toSignedNatural n
+  | n < 0     = Neg (fromInteger (abs n - 1))
+  | otherwise = Pos (fromInteger n)
+
+fromSignedNatural :: Signed Natural -> Integer
+fromSignedNatural (Neg n) = negate (toInteger n + 1)
+fromSignedNatural (Pos n) = toInteger n
+

--- a/src/Test/Falsify/Reexported/Generator/Simple.hs
+++ b/src/Test/Falsify/Reexported/Generator/Simple.hs
@@ -11,6 +11,8 @@ import Data.Bits
 import Test.Falsify.Generator.Auxiliary
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Range (Range(..), origin)
+import Test.Falsify.SampleTree (Sample(..), sampleValue)
+
 import qualified Test.Falsify.Range as Range
 
 {-------------------------------------------------------------------------------
@@ -38,7 +40,7 @@ integer p r =
 --
 -- Chooses with equal probability between 'True' and 'False'.
 bool :: Bool -> Gen Bool
-bool target = aux <$> prim
+bool target = aux . sampleValue <$> primWith shrinker
   where
     aux :: Word64 -> Bool
     aux x | msbSet x  = not target
@@ -46,6 +48,10 @@ bool target = aux <$> prim
 
     msbSet :: forall a. FiniteBits a => a -> Bool
     msbSet x = testBit x (finiteBitSize (undefined :: a) - 1)
+
+    shrinker :: Sample -> [Word64]
+    shrinker (Shrunk 0) = []
+    shrinker _          = [0]
 
 -- | Uniform selection of random value in the specified range
 integral :: forall a. (Integral a, FiniteBits a) => Range a -> Gen a

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import Test.Tasty
 
 import qualified TestSuite.Sanity.Auxiliary
 import qualified TestSuite.Sanity.Compound
+import qualified TestSuite.Sanity.Functions
 import qualified TestSuite.Sanity.Prim
 import qualified TestSuite.Sanity.Range
 import qualified TestSuite.Sanity.Selective
@@ -18,5 +19,6 @@ main = defaultMain $ testGroup "falsify" [
         , TestSuite.Sanity.Simple.tests
         , TestSuite.Sanity.Compound.tests
         , TestSuite.Sanity.Selective.tests
+        , TestSuite.Sanity.Functions.tests
         ]
     ]

--- a/test/TestSuite/Sanity/Functions.hs
+++ b/test/TestSuite/Sanity/Functions.hs
@@ -1,0 +1,162 @@
+module TestSuite.Sanity.Functions (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Word
+
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set           as Set
+
+import Test.Falsify.Generator (Gen, Fun, pattern Fn)
+
+import qualified Test.Falsify.Generator  as Gen
+import qualified Test.Falsify.Range      as Range
+import qualified Test.Falsify.SampleTree as SampleTree
+
+tests :: TestTree
+tests = testGroup "TestSuite.Sanity.Functions" [
+      testGroup "BoolToBool" [
+          testCase "notConstant" test_BoolToBool_notConstant
+        , testCase "constant"    test_BoolToBool_constant
+        ]
+    , testGroup "Word8ToBool" [
+          testCase "constant" test_Word8ToBool_constant
+        ]
+    , testGroup "IntegerToBool" [
+          testCase "constant" test_IntegerToBool_constant
+        ]
+    , testGroup "IntToInt" [
+          testCase "mapFilter" test_IntToInt_mapFilter
+        ]
+    , testCase "StringToBool" test_StringToBool
+    ]
+
+{-------------------------------------------------------------------------------
+  Functions @Bool -> Bool@
+-------------------------------------------------------------------------------}
+
+test_BoolToBool_notConstant :: Assertion
+test_BoolToBool_notConstant = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 1)
+  where
+    expected :: String
+    expected = "{_->False}"
+
+    gen :: Gen (Fun Bool Bool)
+    gen = Gen.fun (Gen.bool False)
+
+    -- "No function Bool -> Bool can be constant"
+    prop :: Fun Bool Bool -> Bool
+    prop (Fn f) = f False /= f True
+
+test_BoolToBool_constant :: Assertion
+test_BoolToBool_constant = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    expected :: String
+    expected = "{True->True, _->False}"
+
+    gen :: Gen (Fun Bool Bool)
+    gen = Gen.fun (Gen.bool False)
+
+    -- "Every function Bool -> Bool is constant"
+    prop :: Fun Bool Bool -> Bool
+    prop (Fn f) = f False == f True
+
+{-------------------------------------------------------------------------------
+  Functions @Word8 -> Bool@
+-------------------------------------------------------------------------------}
+
+test_Word8ToBool_constant :: Assertion
+test_Word8ToBool_constant = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 0)
+  where
+    expected :: String
+    expected = "{1->True, _->False}"
+
+    gen :: Gen (Fun Word8 Bool)
+    gen = Gen.fun (Gen.bool False)
+
+    -- "Every function Word8 -> Bool is constant"
+    prop :: Fun Word8 Bool -> Bool
+    prop (Fn f) =
+        (\s -> Set.size s == 1) $
+          Set.fromList (map f [minBound .. maxBound])
+
+{-------------------------------------------------------------------------------
+  Functions @Integer -> Bool@
+
+  This is the first test where the input domain is infinite.
+-------------------------------------------------------------------------------}
+
+test_IntegerToBool_constant :: Assertion
+test_IntegerToBool_constant = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 4)
+  where
+    expected :: String
+    expected = "{1618->True, _->False}"
+
+    gen :: Gen (Fun Integer Bool)
+    gen = Gen.fun (Gen.bool False)
+
+    -- "Every fn from Integer to Bool must give the same result for π and φ"
+    prop :: Fun Integer Bool -> Bool
+    prop (Fn f) = f 3142 == f 1618
+
+{-------------------------------------------------------------------------------
+  Functions @Int -> Int@
+-------------------------------------------------------------------------------}
+
+test_IntToInt_mapFilter :: Assertion
+test_IntToInt_mapFilter = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 1)
+  where
+    expected :: String
+    expected = "({_->0},{17->True, _->False},[17])"
+
+    gen :: Gen (Fun Int Int, Fun Int Bool, [Int])
+    gen =
+            (,,)
+        <$> Gen.fun
+              (Gen.integral $ Range.between (0, 100))
+        <*> Gen.fun
+              (Gen.bool False)
+        <*> Gen.list
+              (Range.between (0, 10))
+              (Gen.integral $ Range.between (0, 100))
+
+    prop :: (Fun Int Int, Fun Int Bool, [Int]) -> Bool
+    prop (Fn f, Fn p, xs) =
+        map f (filter p xs) == filter p (map f xs)
+
+{-------------------------------------------------------------------------------
+  Functions @String -> Bool@
+
+  This example (as well as 'test_IntToInt_mapFilter') is adapted from
+  Koen Claessen's presentation "Shrinking and showing functions"
+  at Haskell Symposium 2012 <https://www.youtube.com/watch?v=CH8UQJiv9Q4>.
+-------------------------------------------------------------------------------}
+
+test_StringToBool :: Assertion
+test_StringToBool = do
+    assertEqual "" expected $
+      show . NE.last $ Gen.shrink (not . prop) gen (SampleTree.fromSeed 1)
+  where
+    expected :: String
+    expected = "{\"Standard ML\"->True, _->False}"
+
+    gen :: Gen (Fun String Bool)
+    gen = Gen.fun (Gen.bool False)
+
+    prop :: Fun String Bool -> Bool
+    prop (Fn p) = p "Standard ML" `implies` p "Haskell"
+
+    implies :: Bool -> Bool -> Bool
+    implies False _ = True
+    implies True  b = b
+

--- a/test/TestSuite/Sanity/Prim.hs
+++ b/test/TestSuite/Sanity/Prim.hs
@@ -221,11 +221,6 @@ test_either = do
           ]
     assertEqual "gen2" expectedHistory2 $
       Gen.shrink (not . prop) gen2 (tree2 4)
-
-    -- TODO: Might this is in fact OK to do for Either, /by default/..? Is
-    -- everything is lazy enough that only the parts we look at are generated,
-    -- and as we shrink, the other parts should be GCed as we go? Unsure. Need
-    -- to think carefully/experiment.
   where
     gen1 :: Gen (Either Word64 Word64)
     gen1 = do


### PR DESCRIPTION
This also fixes the shrinker for bool, which was using the full 64-bit precision, where 1 sufficed. This significantly improves the performance of the generator.

Performance is not great; but I think this is a general problem with `fromShrinkTree`. Perhaps we can improve this by changing shrinking so that along with a new sample tree, we also get a new generator. This might also give us a nicer way to deal with initializing the sample tree.

Closes #11.