### PR TITLE
Add `chooseAny`, a version of choose that takes NonEmpty (Gen a)

### DIFF
--- a/lib/src/Test/Falsify/Generator.hs
+++ b/lib/src/Test/Falsify/Generator.hs
@@ -15,6 +15,7 @@ module Test.Falsify.Generator (
     -- * Compound generators
     -- ** Taking advantage of 'Selective'
   , choose
+  , chooseAny
     -- ** Lists
   , list
   , elem

--- a/lib/src/Test/Falsify/Reexported/Generator/Compound.hs
+++ b/lib/src/Test/Falsify/Reexported/Generator/Compound.hs
@@ -2,6 +2,7 @@
 module Test.Falsify.Reexported.Generator.Compound (
     -- * Taking advantage of 'Selective'
     choose
+  , chooseAny
     -- * Lists
   , list
   , elem
@@ -102,6 +103,13 @@ import qualified Test.Falsify.Range as Range
 -- conditionally use a value is to use the selective interface, as we do here.
 choose :: Gen a -> Gen a -> Gen a
 choose = ifS (bool True)
+
+
+-- | Generate a value with one of many generators
+--
+-- Uniformly selects a generator and shrinks towards the first one.
+chooseAny :: NonEmpty (Gen a) -> Gen a
+chooseAny gens = frequency $ map (1,) $ NE.toList gens
 
 {-------------------------------------------------------------------------------
   Auxiliary: marking elements


### PR DESCRIPTION
I'm not sure if this is maybe significantly slower, but it was the most straightforward way to implement it.