### PR TITLE
Allow ghc 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.8.2
+            compilerKind: ghc
+            compilerVersion: 9.8.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.6.5
             compilerKind: ghc
             compilerVersion: 9.6.5

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,14 +28,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.3
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.3
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.7
+          - compiler: ghc-9.4.8
             compilerKind: ghc
-            compilerVersion: 9.4.7
+            compilerVersion: 9.4.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -60,10 +60,10 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.22.0/x86_64-linux-ghcup-0.1.22.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -81,7 +81,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -124,7 +124,7 @@ ghcup-cabal: True
 ghcup-jobs: >8.10.4 && <9 || >9.0.1
 
 -- ghcup version
-ghcup-version: 0.1.19.5
+ghcup-version: 0.1.22.0
 
 -- Additional apt packages to install
 apt:

--- a/demo/demo.cabal
+++ b/demo/demo.cabal
@@ -10,8 +10,8 @@ build-type:         Simple
 tested-with:        GHC==8.10.7
                   , GHC==9.0.2
                   , GHC==9.2.8
-                  , GHC==9.4.7
-                  , GHC==9.6.3
+                  , GHC==9.4.8
+                  , GHC==9.6.5
 
 common lang
   ghc-options:

--- a/demo/demo.cabal
+++ b/demo/demo.cabal
@@ -12,6 +12,7 @@ tested-with:        GHC==8.10.7
                   , GHC==9.2.8
                   , GHC==9.4.8
                   , GHC==9.6.5
+                  , GHC==9.8.2
 
 common lang
   ghc-options:

--- a/lib/falsify.cabal
+++ b/lib/falsify.cabal
@@ -30,6 +30,7 @@ tested-with:        GHC==8.10.7
                   , GHC==9.2.8
                   , GHC==9.4.8
                   , GHC==9.6.5
+                  , GHC==9.8.2
 
 source-repository head
   type:     git
@@ -41,7 +42,7 @@ common lang
       -Wredundant-constraints
       -Widentities
   build-depends:
-      base >= 4.12 && < 4.19
+      base >= 4.12 && < 4.20
   default-language:
       Haskell2010
   default-extensions:

--- a/lib/falsify.cabal
+++ b/lib/falsify.cabal
@@ -28,8 +28,8 @@ extra-doc-files:    CHANGELOG.md
 tested-with:        GHC==8.10.7
                   , GHC==9.0.2
                   , GHC==9.2.8
-                  , GHC==9.4.7
-                  , GHC==9.6.3
+                  , GHC==9.4.8
+                  , GHC==9.6.5
 
 source-repository head
   type:     git

--- a/lib/falsify.cabal
+++ b/lib/falsify.cabal
@@ -118,7 +118,7 @@ library
   build-depends:
     , base16-bytestring    >= 1.0  && < 1.1
     , binary               >= 0.8  && < 0.9
-    , bytestring           >= 0.10 && < 0.12
+    , bytestring           >= 0.10 && < 0.13
     , containers           >= 0.6  && < 0.7
     , data-default         >= 0.7  && < 0.8
     , mtl                  >= 2.2  && < 2.4
@@ -128,7 +128,7 @@ library
     , sop-core             >= 0.5  && < 0.6
     , splitmix             >= 0.1  && < 0.2
     , tagged               >= 0.8  && < 0.9
-    , tasty                >= 1.3  && < 1.5
+    , tasty                >= 1.3  && < 1.6
     , transformers         >= 0.5  && < 0.7
     , vector               >= 0.12 && < 0.14
   other-extensions:
@@ -159,7 +159,7 @@ test-suite test-falsify
       TestSuite.Util.List
       TestSuite.Util.Tree
   build-depends:
-    , QuickCheck  >= 2.14 && < 2.15
+    , QuickCheck  >= 2.14 && < 2.16
     , tasty-hunit >= 0.10 && < 0.11
 
       -- Inherit bounds from the main library


### PR DESCRIPTION
Allow ghc-9.8 (which is necessary for inclusion into Stackage, see https://github.com/well-typed/falsify/issues/71), and bump some outdated dependencies.