### PR TITLE
Allow data-default-0.8

### DIFF
--- a/lib/falsify.cabal
+++ b/lib/falsify.cabal
@@ -122,7 +122,7 @@ library
     , binary               >= 0.8  && < 0.9
     , bytestring           >= 0.10 && < 0.13
     , containers           >= 0.6  && < 0.8
-    , data-default         >= 0.7  && < 0.8
+    , data-default         >= 0.7  && < 0.9
     , mtl                  >= 2.2  && < 2.4
     , optics-core          >= 0.3  && < 0.5
     , optparse-applicative >= 0.16 && < 0.19


### PR DESCRIPTION
We need to allow data-default-0.8 for continued inclusion in Stackage: https://github.com/commercialhaskell/stackage/issues/7545.

Failing CI will be resolved by https://github.com/well-typed/falsify/pull/74.

