### PR TITLE
Add context for properties

### DIFF
--- a/falsify/falsify.cabal
+++ b/falsify/falsify.cabal
@@ -90,6 +90,7 @@ library
       lang
   exposed-modules:
       Test.Falsify
+      Test.Falsify.Context
       Test.Falsify.Driver
       Test.Falsify.GenDefault
       Test.Falsify.GenDefault.Std
@@ -108,6 +109,7 @@ library
       Data.Falsify.Tree
       Data.Falsify.WordN
   other-modules:
+      Test.Falsify.Internal.Context
       Test.Falsify.Internal.Driver
       Test.Falsify.Internal.Driver.ReplaySeed
       Test.Falsify.Internal.Fun

--- a/falsify/src/Test/Falsify/Context.hs
+++ b/falsify/src/Test/Falsify/Context.hs
@@ -1,0 +1,14 @@
+-- | Context
+--
+-- Intended for qualified import.
+--
+-- > import Test.Falsify
+-- > import qualified Test.Falsify.Context as Context
+module Test.Falsify.Context (
+    Context.Context(..)
+  , getContext
+  ) where
+
+import Test.Falsify.Internal.Property (getContext)
+
+import qualified Test.Falsify.Internal.Context as Context

--- a/falsify/src/Test/Falsify/Internal/Context.hs
+++ b/falsify/src/Test/Falsify/Internal/Context.hs
@@ -1,0 +1,49 @@
+-- | Context
+--
+-- Intended for qualified import.
+--
+-- > import Test.Falsify.Internal.Context (Context(Context))
+-- > import qualified Test.Falsify.Internal.Context as Context
+module Test.Falsify.Internal.Context (
+    -- * Context
+    Context(..)
+  ) where
+
+-- | Contextual data for a single test case
+--
+-- Properties can access contextual data pertaining to the current test case in
+-- a test run. An example of its use is varying the range of generated values
+-- depending on how many tests we have already done, generating a smaller range
+-- in the beginning but widening the range later on.
+--
+-- All tests are initially run with 'finalShrink' set @False@. When we stop
+-- shrinking, the final valid counterexample will be rerun with @finalShrink@
+-- set @True@. It is not allowed to have this parameter affect the outcome of
+-- the test. Note that in uncommon cases, the test case might not actually be a
+-- shrink ('thisShrink' = @Nothing@), either because we could not shrink at all
+-- or because 'maxShrinks' is @Just 0@.
+--
+-- Fields labeled /constant/ are the same for all tests in the test run, and
+-- come from t'Test.Falsify.Driver.Options'.
+data Context = Context {
+      -- | Number of test cases to generate (constant)
+      tests :: Word
+
+      -- | Number of current test case, 1-based
+    , thisTest :: Word
+
+      -- | Number of shrinks allowed before failing a test (constant)
+    , maxShrinks :: Maybe Word
+
+      -- | Number of current shrink, 1-based
+      --
+      -- @Nothing@ when we're not currently shrinking
+    , thisShrink :: Maybe Word
+
+      -- | Is this the final counterexample after shrinking?
+    , finalShrink :: Bool
+
+      -- | Maximum number of discarded tests per successful test (constant)
+    , maxRatio :: Word
+    }
+  deriving (Show)

--- a/falsify/src/Test/Falsify/Internal/Driver.hs
+++ b/falsify/src/Test/Falsify/Internal/Driver.hs
@@ -37,12 +37,14 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map           as Map
 import qualified Data.Set           as Set
 
+import Test.Falsify.Internal.Context (Context(Context))
 import Test.Falsify.Internal.Driver.ReplaySeed
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Internal.Property
 import Test.Falsify.Internal.Shrinking
 import Test.Falsify.SampleTree (SampleTree)
 
+import qualified Test.Falsify.Internal.Context as Context
 import qualified Test.Falsify.SampleTree as SampleTree
 
 {-------------------------------------------------------------------------------
@@ -125,9 +127,20 @@ falsify opts prop = do
       }
   where
     go :: DriverState a -> IO ([Success a], Word, Maybe (Failure e))
-    go acc | todo acc == 0 = return (successes acc, discardedTotal acc, Nothing)
+    go acc | thisTest acc > tests opts
+           = return (successes acc, discardedTotal acc, Nothing)
     go acc = do
-        let now, later :: SMGen
+        let ctx :: Context
+            ctx = Context{
+                tests       = tests opts
+              , thisTest    = thisTest acc
+              , maxShrinks  = maxShrinks opts
+              , thisShrink  = Nothing
+              , finalShrink = False
+              , maxRatio    = maxRatio opts
+              }
+
+            now, later :: SMGen
             (now, later) = splitSMGen (prng acc)
 
             st :: SampleTree
@@ -136,7 +149,7 @@ falsify opts prop = do
             result :: TestResult e a
             run    :: TestRun
             shrunk :: [SampleTree]
-            ((result, run), shrunk) = runGen (runProperty prop) st
+            ((result, run), shrunk) = runGen (runProperty prop ctx) st
 
         case result of
           -- Test passed
@@ -159,13 +172,23 @@ falsify opts prop = do
           -- We ignore the failure message here, because this is the failure
           -- message before shrinking, which we are typically not interested in.
           TestFailed e -> do
-            let explanation :: ShrinkExplanation (e, TestRun) TestRun
+            let explanation, explanation' :: ShrinkExplanation (e, TestRun) TestRun
                 explanation =
-                    limitShrinkSteps (maxShrinks opts) . second snd $
+                    second snd $
                       shrinkFrom
+                        (maxShrinks opts)
                         resultIsValidShrink
                         (runProperty prop)
+                        ctx
                         ((e, run), shrunk)
+
+                explanation' = case history explanation of
+                    ShrunkTo _ _ -> explanation
+                    _            -> explanation{initial = finalInitial}
+
+                finalInitial :: (e, TestRun)
+                finalInitial =
+                  finalShrink resultIsValidShrink (runProperty prop) ctx st
 
                 -- We have to be careful here: if the user specifies a seed, we
                 -- will first /split/ it to run the test (call to splitSMGen,
@@ -174,7 +197,7 @@ falsify opts prop = do
                 failure :: Failure e
                 failure = Failure {
                       failureSeed = splitmixReplaySeed (prng acc)
-                    , failureRun  = explanation
+                    , failureRun  = explanation'
                     }
 
             return (successes acc, discardedTotal acc, Just failure)
@@ -198,14 +221,14 @@ data DriverState a = DriverState {
       -- | Accumulated successful tests
     , successes :: [Success a]
 
-      -- | Number of tests still to execute
-    , todo :: Word
-
       -- | Number of tests we discarded so far (for this test)
     , discardedForTest :: Word
 
       -- | Number of tests we discarded (in total)
     , discardedTotal :: Word
+
+      -- | Current test number
+    , thisTest :: Word
     }
   deriving (Show)
 
@@ -219,27 +242,27 @@ initDriverState opts = do
     return $ DriverState {
         prng
       , successes        = []
-      , todo             = tests opts
       , discardedForTest = 0
       , discardedTotal   = 0
+      , thisTest         = 1
       }
 
 withSuccess :: SMGen -> Success a -> DriverState a -> DriverState a
 withSuccess next success acc = DriverState {
       prng             = next
     , successes        = success : successes acc
-    , todo             = pred (todo acc)
     , discardedForTest = 0 -- reset for the next test
     , discardedTotal   = discardedTotal acc
+    , thisTest         = succ (thisTest acc)
     }
 
 withDiscard :: SMGen -> DriverState a -> DriverState a
 withDiscard next acc = DriverState {
       prng             = next
     , successes        = successes acc
-    , todo             = todo acc
     , discardedForTest = succ $ discardedForTest acc
     , discardedTotal   = succ $ discardedTotal acc
+    , thisTest         = thisTest acc
     }
 
 {-------------------------------------------------------------------------------

--- a/falsify/src/Test/Falsify/Internal/Property.hs
+++ b/falsify/src/Test/Falsify/Internal/Property.hs
@@ -25,6 +25,7 @@ module Test.Falsify.Internal.Property (
   , discard
   , label
   , collect
+  , getContext
     -- * Testing shrinking
   , testShrinking
   , testMinimum
@@ -37,6 +38,7 @@ module Test.Falsify.Internal.Property (
 import Prelude hiding (log)
 
 import Control.Monad
+import Control.Monad.Reader
 import Control.Monad.State
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty)
@@ -48,10 +50,12 @@ import GHC.Stack
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
+import Test.Falsify.Internal.Context (Context(Context))
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Internal.Shrinking
 import Test.Falsify.Predicate (Predicate, (.$))
 
+import qualified Test.Falsify.Internal.Context as Context
 import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 
@@ -101,7 +105,7 @@ initTestRun = TestRun {
 -- This is an internal function, used when testing shrinking to include the runs
 -- from an unshrunk test and a shrunk test.
 appendLog :: Log -> Property' e ()
-appendLog (Log log') = mkProperty $ \run@TestRun{runLog = Log log} -> return (
+appendLog (Log log') = mkProperty $ \_ctx run@TestRun{runLog = Log log} -> return (
       TestPassed ()
     , run{runLog = Log $ log' ++ log}
     )
@@ -173,7 +177,7 @@ instance Monad m => Monad (TestResultT e m) where
 -- In most cases, you will probably want to use t'Test.Falsify.Property.Property'
 -- instead, which fixes @e@ at 'String'.
 newtype Property' e a = WrapProperty {
-      unwrapProperty :: TestResultT e (StateT TestRun Gen) a
+      unwrapProperty :: TestResultT e (ReaderT Context (StateT TestRun Gen)) a
     }
   deriving newtype (Functor, Applicative, Monad)
 
@@ -186,12 +190,13 @@ type Property = Property' String
 -- | Construct property
 --
 -- This is a low-level function for internal use only.
-mkProperty :: (TestRun -> Gen (TestResult e a, TestRun)) -> Property' e a
-mkProperty = WrapProperty . TestResultT . StateT
+mkProperty :: (Context -> TestRun -> Gen (TestResult e a, TestRun)) -> Property' e a
+mkProperty f = WrapProperty $ TestResultT $ ReaderT $ \ctx -> StateT (f ctx)
 
 -- | Run property
-runProperty :: Property' e a -> Gen (TestResult e a, TestRun)
-runProperty = flip runStateT initTestRun . runTestResultT . unwrapProperty
+runProperty :: Property' e a -> Context -> Gen (TestResult e a, TestRun)
+runProperty p ctx =
+    flip runStateT initTestRun $ flip runReaderT ctx $ runTestResultT $ unwrapProperty p
 
 {-------------------------------------------------------------------------------
   'Property' features
@@ -199,18 +204,18 @@ runProperty = flip runStateT initTestRun . runTestResultT . unwrapProperty
 
 -- | Test failure
 testFailed :: e -> Property' e a
-testFailed err = mkProperty $ \run -> return (TestFailed err, run)
+testFailed err = mkProperty $ \_ctx run -> return (TestFailed err, run)
 
 -- | Discard this test
 discard :: Property' e a
-discard = mkProperty $ \run -> return (TestDiscarded, run)
+discard = mkProperty $ \_ctx run -> return (TestDiscarded, run)
 
 -- | Log some additional information about the test
 --
 -- This will be shown in verbose mode.
 info :: String -> Property' e ()
 info msg =
-    mkProperty $ \run@TestRun{runLog = Log log} -> return (
+    mkProperty $ \_ctx run@TestRun{runLog = Log log} -> return (
         TestPassed ()
       , run{runLog = Log $ Info msg : log}
       )
@@ -227,7 +232,7 @@ assert p =
 -- See 'collect' for detailed discussion.
 label :: String -> [String] -> Property' e ()
 label lbl vals =
-    mkProperty $ \run@TestRun{runLabels} -> return (
+    mkProperty $ \_ctx run@TestRun{runLabels} -> return (
         TestPassed ()
       , run{runLabels = Map.alter addValues lbl runLabels}
       )
@@ -299,6 +304,11 @@ collect l = label l . map show
 instance MonadFail (Property' String) where
   fail = testFailed
 
+
+-- | Get the context for the current test run
+getContext :: Property' e Context
+getContext = mkProperty $ \ctx run -> return (TestPassed ctx, run)
+
 {-------------------------------------------------------------------------------
   Running generators
 -------------------------------------------------------------------------------}
@@ -309,7 +319,7 @@ genWithCallStack :: forall e a.
                          -- (users don't care that 'gen' uses 'genWith').
   -> (a -> Maybe String) -- ^ Entry to add to the log (if any)
   -> Gen a -> Property' e a
-genWithCallStack stack f g = mkProperty $ \run -> aux run <$> g
+genWithCallStack stack f g = mkProperty $ \_ctx run -> aux run <$> g
   where
     aux :: TestRun -> a -> (TestResult e a, TestRun)
     aux run@TestRun{runLog = Log log} x = (
@@ -338,8 +348,16 @@ genWith = genWithCallStack callStack
 -- | Construct random path through the property's shrink tree
 genShrinkPath :: Property' e () -> Property' e' [(e, TestRun)]
 genShrinkPath prop = do
+    let ctx = Context {
+              tests = 1
+            , thisTest = 1
+            , maxShrinks = Nothing
+            , thisShrink = Nothing
+            , finalShrink = False
+            , maxRatio = 100
+            }
     st    <- genWith (const Nothing) $
-               Gen.toShrinkTree (runProperty prop)
+               Gen.toShrinkTree (runProperty prop ctx)
     mPath <- genWith (const Nothing) $
                Gen.path (isValidShrink . resultIsValidShrink) st
     aux mPath
@@ -403,8 +421,16 @@ testMinimum :: forall e.
   -> Property' e ()
   -> Property' String ()
 testMinimum p prop = do
+    let ctx = Context {
+              tests       = 1
+            , thisTest    = 1
+            , maxShrinks  = Nothing
+            , thisShrink  = Nothing
+            , finalShrink = False
+            , maxRatio    = 100
+            }
     st <- genWith (const Nothing) $ Gen.captureLocalTree
-    case runGen (runProperty prop) st of
+    case runGen (runProperty prop ctx) st of
       ((TestPassed (), _run), _shrunk) ->
         -- The property passed; nothing to test
         discard
@@ -412,16 +438,27 @@ testMinimum p prop = do
         -- The property needs to be discarded; discard this one, too
         discard
       ((TestFailed initErr, initRun), shrunk) -> do
-        let explanation :: ShrinkExplanation (e, TestRun) (Maybe (), TestRun)
+        let explanation, explanation' ::
+              ShrinkExplanation (e, TestRun) (Maybe (), TestRun)
             explanation = shrinkFrom
+                            Nothing
                             resultIsValidShrink
                             (runProperty prop)
+                            ctx
                             ((initErr, initRun), shrunk)
+
+            explanation' = case history explanation of
+                ShrunkTo _ _ -> explanation
+                _            -> explanation{initial = finalInitial}
+
+            finalInitial :: (e, TestRun)
+            finalInitial =
+              finalShrink resultIsValidShrink (runProperty prop) ctx st
 
             minErr    :: e
             minRun    :: TestRun
             mRejected :: Maybe [(Maybe (), TestRun)]
-            ((minErr, minRun), mRejected) = shrinkOutcome explanation
+            ((minErr, minRun), mRejected) = shrinkOutcome explanation'
 
             rejected :: [TestRun]
             rejected  = maybe [] (map snd) mRejected
@@ -453,7 +490,7 @@ testGen p = testGen' $ \a -> P.eval $ p .$ ("generated", a)
 
 -- | Generalization of 'testGen'
 testGen' :: forall e a b. (a -> Either e b) -> Gen a -> Property' e b
-testGen' p g = WrapProperty $ TestResultT $ StateT $ \run ->
+testGen' p g = WrapProperty $ TestResultT $ ReaderT $ \_ctx -> StateT $ \run ->
     -- We do not use bind here to avoid introducing new shrinking shortcuts
     aux run <$> g
   where

--- a/falsify/src/Test/Falsify/Internal/Shrinking.hs
+++ b/falsify/src/Test/Falsify/Internal/Shrinking.hs
@@ -6,7 +6,7 @@ module Test.Falsify.Internal.Shrinking (
   , ShrinkHistory(..)
   , IsValidShrink(..)
   , isValidShrink
-  , limitShrinkSteps
+  , finalShrink
   , shrinkHistory
   , shrinkOutcome
   ) where
@@ -15,8 +15,11 @@ import Data.Bifunctor
 import Data.Either
 import Data.List.NonEmpty (NonEmpty((:|)))
 
+import Test.Falsify.Internal.Context (Context)
 import Test.Falsify.Internal.Generator
 import Test.Falsify.SampleTree (SampleTree(..))
+
+import qualified Test.Falsify.Internal.Context as Context
 
 {-------------------------------------------------------------------------------
   Explanation
@@ -52,21 +55,6 @@ data ShrinkHistory p n =
     -- This is used when the number of shrink steps is limited.
   | ShrinkingStopped
   deriving (Show)
-
-limitShrinkSteps :: Maybe Word -> ShrinkExplanation p n -> ShrinkExplanation p n
-limitShrinkSteps Nothing      = id
-limitShrinkSteps (Just limit) = \case
-    ShrinkExplanation{initial, history} ->
-      ShrinkExplanation{
-          initial
-        , history = go limit history
-        }
-  where
-    go :: Word -> ShrinkHistory p n -> ShrinkHistory p n
-    go 0 (ShrunkTo _ _)      = ShrinkingStopped
-    go n (ShrunkTo x xs)     = ShrunkTo x (go (pred n) xs)
-    go _ (ShrinkingDone rej) = ShrinkingDone rej
-    go _ ShrinkingStopped    = ShrinkingStopped
 
 -- | Simplify the shrink explanation to keep only the shrink history
 shrinkHistory :: ShrinkExplanation p n -> NonEmpty p
@@ -134,6 +122,28 @@ isValidShrink :: IsValidShrink p n -> Either n p
 isValidShrink (ValidShrink p)   = Right p
 isValidShrink (InvalidShrink n) = Left n
 
+-- | Rerun the final shrink with the context flag 'Test.Falsify.Context.finalShrink'
+-- asserted
+finalShrink :: forall a p n.
+     (a -> IsValidShrink p n)
+  -> (Context -> Gen a)
+  -> Context
+  -> SampleTree
+  -> p
+finalShrink prop gen ctx st =
+    case prop a of
+      ValidShrink p -> p
+      _             -> error finalErrorMsg
+  where
+    a =
+      fst $
+        runGen
+          (gen ctx{Context.finalShrink = True})
+          st
+
+    finalErrorMsg :: String
+    finalErrorMsg = "Inconsistent test: failing test did not fail with finalShrink True"
+
 -- | Find smallest value that the generator can produce and still satisfies
 -- the predicate.
 --
@@ -142,33 +152,45 @@ isValidShrink (InvalidShrink n) = Left n
 -- To avoid boolean blindness, we use different types for values that satisfy
 -- the property and values that do not.
 --
--- This is lazy in the shrink history; see 'limitShrinkSteps' to limit the
--- number of shrinking steps.
+-- This is lazy in the shrink history.
 shrinkFrom :: forall a p n.
-     (a -> IsValidShrink p n)
-  -> Gen a
+     Maybe Word -- ^ Limit amount of shrinking steps
+  -> (a -> IsValidShrink p n)
+  -> (Context -> Gen a)
+  -> Context
   -> (p, [SampleTree]) -- ^ Initial result of the generator
   -> ShrinkExplanation p n
-shrinkFrom prop gen = \(p, shrunk) ->
-    ShrinkExplanation p $ go shrunk
+shrinkFrom limit prop gen ctx = \(p, shrunk) ->
+    ShrinkExplanation p $ go 1 shrunk
   where
-    go :: [SampleTree] -> ShrinkHistory p n
-    go shrunk =
+    go i shrunk =
         -- Shrinking is a greedy algorithm: we go with the first candidate that
         -- works, and discard the others.
-        --
+        if | ([], rejected) <- candidates
+           -> ShrinkingDone rejected
+           | Just li <- limit
+           , i > li
+           -> ShrinkingStopped
+           | ((st, p, shrunk'):_, _) <- candidates
+           -> let next :: ShrinkHistory p n
+                  next = go (succ i) shrunk'
+              in case next of
+                   ShrunkTo _ _ -> ShrunkTo p next
+                   _            -> ShrunkTo (finalShrink prop gen ctx' st) next
+      where
         -- NOTE: 'partitionEithers' is lazy enough:
         --
         -- > head . fst $ partitionEithers [Left True, undefined] == True
-        case partitionEithers candidates of
-          ([], rejected)      -> ShrinkingDone rejected
-          ((p, shrunk'):_, _) -> ShrunkTo p $ go shrunk'
-      where
-        candidates :: [Either (p, [SampleTree]) n]
-        candidates = map consider $ map (runGen gen) shrunk
+        candidates :: ([(SampleTree, p, [SampleTree])], [n])
+        candidates = partitionEithers $ map consider shrunk
 
-    consider :: (a, [SampleTree]) -> Either (p, [SampleTree]) n
-    consider (a, shrunk) =
-        case prop a of
-          ValidShrink p   -> Left (p, shrunk)
-          InvalidShrink n -> Right n
+        consider :: SampleTree -> Either (SampleTree, p, [SampleTree]) n
+        consider st =
+            case prop a of
+              ValidShrink p   -> Left (st, p, shrunk')
+              InvalidShrink n -> Right n
+          where
+            (a, shrunk') = runGen (gen ctx') st
+
+        ctx' :: Context
+        ctx' = ctx{Context.thisShrink = Just i}


### PR DESCRIPTION
As discussed last Thursday with @edsko and @martijnbastiaan.

With `Context`, a `Property` can access contextual data pertaining to the current test case in a test run.

An example of its use is varying the range of generated values depending on how many tests we have already done, generating a smaller range in the beginning but widening the range later on.

Notes:
* The functionality of the  function `limitShrinkSteps` was folded into `shrinkFrom` as it needs to be able to rerun the final test case with `Context.finalShrink` asserted, and `limitShrinkSteps` did not have enough information for that.
* I chose `error` to handle the inconsistency of a test that fails with `finalShrink` deasserted but does not fail with `finalShrink` asserted. This is clearly a faulty property, but maybe there needs to be proper error handling instead of bottoming?
* I haven't added any tests. Feel free to ask for them if you think that's better. I did try some stuff manually, of course.
* `DriverState`'s `todo` and new `thisTest` encoded the same datum, so I dropped `todo`.
* I was unsure what the context should be for `genShrinkPath` and `getMinimum`. Please verify this is what you consider appropriate.
* The feature we at QBayLogic are interested in is the `finalShrink` field of `Context`, which, in combination with some way to do IO in a property, should allow us to output debugging data for the final counterexample, where the debugging data is expensive to compute.
* Hmmmm. Now that I think about it, there seems to be another solution for expensive debugging data. You could also have the `Property' e a` output its debugging data lazily in `e`, and then use `failure <$> falsify ....` to access the debugging data of the final counterexample and produce the concrete data. I think. It could greatly increase memory usage, though, since it will keep a thunk for the `e` for all the counterexamples in `TestOutcome'`. That might be a serious drawback. Hah! You could use this PR's `finalShrink` to fix that!