### PR TITLE
Fully integrate new `Context`

### DIFF
--- a/demo/demo.cabal
+++ b/demo/demo.cabal
@@ -57,6 +57,7 @@ executable demo
       Main.hs
   other-modules:
       Demo.Blogpost
+      Demo.Context
       Demo.Distribution
       Demo.Functions
       Demo.HowToSpecifyIt

--- a/demo/demo/Demo/Context.hs
+++ b/demo/demo/Demo/Context.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Demo.Context (tests) where
+
+import Test.Tasty
+import Test.Tasty.Falsify
+import Data.Word
+
+import Test.Falsify
+import qualified Data.Falsify.ProperFraction as ProperFraction
+import qualified Test.Falsify.Context        as Context
+import qualified Test.Falsify.Generator      as Gen
+import qualified Test.Falsify.Predicate      as P
+import qualified Test.Falsify.Range          as Range
+
+tests :: TestTree
+tests = testGroup "Demo.Context" [
+      testProperty "demo1"  demo1
+    , testProperty "demo2a" demo2a
+    , testProperty "demo2b" demo2b
+    ]
+
+{-------------------------------------------------------------------------------
+  Show 'Context'
+-------------------------------------------------------------------------------}
+
+-- | Obviously false property
+--
+-- Run with
+--
+-- > cabal run -- demo -p Context --falsify-verbose
+--
+-- The point of this demo is simply to show how the execution 'Context' evolves.
+demo1 :: Property ()
+demo1 = do
+    x    <- gen Gen.prim
+    ctxt <- getContext
+    info $ concat [
+        "demo1: "
+      , "generated " ++ show x
+      , " in step " ++ show (Context.execution ctxt)
+      ]
+    assert $ P.expect 0 .$ ("x", x)
+
+{-------------------------------------------------------------------------------
+  Take advantage of the 'Context' to increase rangep
+-------------------------------------------------------------------------------}
+
+-- | "No number is equal to 5"
+--
+-- Obviously false, but hard to find a counter-example!
+demo2a :: Property ()
+demo2a = do
+    x <- gen Gen.prim
+    assert $ P.ne .$ ("forbidden", 5) .$ ("x", x :: Word64)
+
+-- | .. but if we start with a small range and then increase, we always find it
+demo2b :: Property ()
+demo2b = do
+    ctxt <- getContext
+    l <- sized $ ProperFraction.scaleIntegral 100
+    x <- gen $ Gen.inRange $ Range.inclusive (0, l)
+    info (show (ctxt, l, x))
+    assert $ P.ne .$ ("forbidden", 5) .$ ("x", x :: Word64)

--- a/demo/demo/Main.hs
+++ b/demo/demo/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Tasty
 
 import qualified Demo.Blogpost
+import qualified Demo.Context
 import qualified Demo.Distribution
 import qualified Demo.Functions
 import qualified Demo.HowToSpecifyIt
@@ -19,4 +20,5 @@ main = defaultMain $ testGroup "demo" [
     , Demo.HowToSpecifyIt.tests
     , Demo.Blogpost.tests
     , Demo.Predicates.tests
+    , Demo.Context.tests
     ]

--- a/falsify/CHANGELOG.md
+++ b/falsify/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Revision history for falsify
 
-## 0.4.0 -- ??
+## 0.4.0 -- 2026-07-01
 
 This release is a major cleanup release, and backwards incompatible with 0.3 in
 various ways. Below we provide a list of changes as well as a migration guide.
+
+### New features
+
+* `Test.Falsify.Interactive` now offers a pure function `sampleUsing` (#65),
+  using `ReplaySeed` to initialize the PRNG. `ReplaySeed` is no longer opaque.
+* `Property` now offers `getContext`, which allows properties to vary their
+  behaviour across different test iterations; for example, tests might want to
+  start with generating values from small ranges and then slowly increase that
+  range. There is also a derived function `sized` for that specific application.
+  (#102, together with Peter Lebbing and Martijn Bastiaan from QBayLogic)
 
 ### Package split: `falsify` vs `tasty-falsify`
 
@@ -81,8 +91,6 @@ A number of type aliases have been replaced by newtypes.
   are a more natural fit when used together with `lam` to construct predicates
   of arbitrary arity. To consider the old `alwaysFail`, use `Fail "Fail"`.
 * Predicate documentation has been significantly improved.
-* `Test.Falsify.Interactive` now offers a pure function `sampleUsing` (#65),
-  using `ReplaySeed` to initialize the PRNG. `ReplaySeed` is no longer opaque.
 * Dropped support for GHC < 8.10.7
 
 ## 0.3.0 -- 2026-03-05

--- a/falsify/falsify.cabal
+++ b/falsify/falsify.cabal
@@ -90,6 +90,7 @@ library
       lang
   exposed-modules:
       Test.Falsify
+      Test.Falsify.Context
       Test.Falsify.Driver
       Test.Falsify.GenDefault
       Test.Falsify.GenDefault.Std

--- a/falsify/src/Data/Falsify/ProperFraction.hs
+++ b/falsify/src/Data/Falsify/ProperFraction.hs
@@ -3,8 +3,12 @@
 -- Intended for qualified import.
 --
 -- > import Data.Falsify.ProperFraction (ProperFraction(..))
+-- > import qualified Data.Falsify.ProperFraction as ProperFraction
 module Data.Falsify.ProperFraction (
     ProperFraction(ProperFraction)
+    -- * Use
+  , scaleIntegral
+  , scaleFractional
   ) where
 
 import Prelude hiding (properFraction)
@@ -38,3 +42,14 @@ pattern ProperFraction f <- (getProperFraction -> f)
     ProperFraction = mkProperFraction
 
 {-# COMPLETE ProperFraction #-}
+
+{-------------------------------------------------------------------------------
+  Use
+-------------------------------------------------------------------------------}
+
+scaleIntegral :: Integral a => a -> ProperFraction -> a
+scaleIntegral x (ProperFraction f) = round $ fromIntegral x * f
+
+scaleFractional :: Fractional a => a -> ProperFraction -> a
+scaleFractional x (ProperFraction f) = x * realToFrac f
+

--- a/falsify/src/Test/Falsify.hs
+++ b/falsify/src/Test/Falsify.hs
@@ -29,10 +29,15 @@ module Test.Falsify (
   , Property.label
   , Property.collect
   , Property.info
+  , Property.getContext
+  , Property.sized
     -- ** Testing generators
   , Property.testMinimum
+  , Property.testMinimumForIteration
   , Property.testShrinking
+  , Property.testShrinkingForIteration
   , Property.testShrinkingOfGen
+  , Property.testShrinkingOfGenForIteration
   , Property.testGen
   , Property.testGen'
     -- ** Functions

--- a/falsify/src/Test/Falsify/Context.hs
+++ b/falsify/src/Test/Falsify/Context.hs
@@ -1,0 +1,75 @@
+-- | Context
+--
+-- Intended for qualified import.
+--
+-- > import Test.Falsify
+-- > import Test.Falsify.Context (Context)
+-- > import qualified Test.Falsify.Context as Context
+module Test.Falsify.Context (
+    -- * Context
+    Context(..)
+  , Static(..)
+  , Iteration(..)
+  , Execution(..)
+  ) where
+
+-- | Contextual data for a single test case
+--
+-- Properties can access contextual data pertaining to the current test case in
+-- a test run. An example of its use is varying the range of generated values
+-- depending on how many tests we have already done, generating a smaller range
+-- in the beginning but widening the range later on.
+data Context = Context{
+      static    :: Static
+    , iteration :: Iteration
+    , execution :: Execution
+    }
+  deriving stock (Show, Eq)
+
+-- | Static context
+--
+-- The part of the context that does not change between test iterations.
+data Static = Static{
+      -- | Number of test cases to generate
+      tests :: Word
+
+      -- | Number of shrinks allowed before failing a test
+    , maxShrinks :: Maybe Word
+
+      -- | Maximum number of discarded tests per successful test
+    , maxRatio :: Word
+    }
+  deriving stock (Show, Eq)
+
+-- | Iteration context
+--
+-- Information about the current test iteration specifically.
+data Iteration = Iteration{
+      -- | Number of current test case, 0-based
+      thisTest :: Word
+    }
+  deriving stock (Show, Eq)
+
+-- | Test execution context
+--
+-- NOTE: This should not affect whether the test passes or fails; if it does,
+-- you will get undefined shrinking behaviour.
+data Execution =
+    -- | Initial test execution
+    Initial
+
+    -- | Shrink step
+    --
+    -- We record the index of the shrink step (0-based)
+  | Shrinking Word
+
+    -- | Final test execution
+    --
+    -- We always end a test execution with one more final run, which is a repeat
+    -- of the run that came just before it.
+    --
+    -- We record how many shrink steps we took in between 'Initial' and 'Final';
+    -- this may be zero, if the initial test happened to be minimal already or
+    -- shrinking is disabled.
+  | Final Word
+  deriving stock (Show, Eq)

--- a/falsify/src/Test/Falsify/Driver.hs
+++ b/falsify/src/Test/Falsify/Driver.hs
@@ -32,6 +32,7 @@ import qualified Data.List.NonEmpty as NE
 
 import Test.Falsify.Internal.Driver
 import Test.Falsify.Internal.Driver.ReplaySeed
+import Test.Falsify.Internal.Property
 import Test.Falsify.Internal.Shrinking
 
 {-------------------------------------------------------------------------------
@@ -72,6 +73,6 @@ failure' TestOutcome{testFailure} = aux <$> testFailure
     aux Failure{failureSeed, failureRun} = (
           failureSeed
         ,   shrinkHistory
-          $ first fst      -- Drop the 'TestRun's
+          $ first counterexampleError
           $ failureRun
         )

--- a/falsify/src/Test/Falsify/Generator.hs
+++ b/falsify/src/Test/Falsify/Generator.hs
@@ -48,6 +48,7 @@ module Test.Falsify.Generator (
     -- * Shrink trees
   , fromShrinkTree
   , toShrinkTree
+  , toShrinkTreeWithContext
     -- * Generator independence
   , bindIntegral
   , perturb

--- a/falsify/src/Test/Falsify/Internal/Driver.hs
+++ b/falsify/src/Test/Falsify/Internal/Driver.hs
@@ -37,12 +37,14 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map           as Map
 import qualified Data.Set           as Set
 
+import Test.Falsify.Context (Context(Context))
 import Test.Falsify.Internal.Driver.ReplaySeed
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Internal.Property
 import Test.Falsify.Internal.Shrinking
 import Test.Falsify.SampleTree (SampleTree)
 
+import qualified Test.Falsify.Context    as Context
 import qualified Test.Falsify.SampleTree as SampleTree
 
 {-------------------------------------------------------------------------------
@@ -77,15 +79,16 @@ instance Default Options where
 -------------------------------------------------------------------------------}
 
 data Success a = Success {
-      successResult :: a
-    , successSeed   :: ReplaySeed
-    , successRun    :: TestRun
+      successIteration :: Context.Iteration
+    , successResult    :: a
+    , successSeed      :: ReplaySeed
+    , successRun       :: TestRun
     }
   deriving (Show)
 
 data Failure e = Failure {
       failureSeed :: ReplaySeed
-    , failureRun  :: ShrinkExplanation (e, TestRun) TestRun
+    , failureRun  :: ShrinkExplanation (Counterexample e) TestRun
     }
   deriving (Show)
 
@@ -124,10 +127,29 @@ falsify opts prop = do
       , testFailure    = mFailure
       }
   where
+    static :: Context.Static
+    static = Context.Static{
+          tests      = tests      opts
+        , maxShrinks = maxShrinks opts
+        , maxRatio   = maxRatio   opts
+        }
+
     go :: DriverState a -> IO ([Success a], Word, Maybe (Failure e))
-    go acc | todo acc == 0 = return (successes acc, discardedTotal acc, Nothing)
+    go acc | thisTest acc > tests opts = return (
+          reverse $ successes acc
+        , discardedTotal acc
+        , Nothing
+        )
     go acc = do
-        let now, later :: SMGen
+        let iteration :: Context.Iteration
+            iteration = Context.Iteration{
+                  thisTest = thisTest acc
+                }
+
+            initContext :: Context
+            initContext = Context static iteration Context.Initial
+
+            now, later :: SMGen
             (now, later) = splitSMGen (prng acc)
 
             st :: SampleTree
@@ -136,16 +158,17 @@ falsify opts prop = do
             result :: TestResult e a
             run    :: TestRun
             shrunk :: [SampleTree]
-            ((result, run), shrunk) = runGen (runProperty prop) st
+            ((result, run), shrunk) = runGen (runProperty prop initContext) st
 
         case result of
           -- Test passed
           TestPassed x -> do
             let success :: Success a
                 success = Success {
-                    successResult = x
-                  , successSeed   = splitmixReplaySeed now
-                  , successRun    = run
+                    successIteration = iteration
+                  , successResult    = x
+                  , successSeed      = splitmixReplaySeed now
+                  , successRun       = run
                   }
             if runDeterministic run then
               case (successes acc, discardedTotal acc) of
@@ -159,13 +182,18 @@ falsify opts prop = do
           -- We ignore the failure message here, because this is the failure
           -- message before shrinking, which we are typically not interested in.
           TestFailed e -> do
-            let explanation :: ShrinkExplanation (e, TestRun) TestRun
+            let explanation :: ShrinkExplanation (Counterexample e) TestRun
                 explanation =
-                    limitShrinkSteps (maxShrinks opts) . second snd $
+                    second snd $
                       shrinkFrom
-                        resultIsValidShrink
-                        (runProperty prop)
-                        ((e, run), shrunk)
+                        static
+                        iteration
+                        ( \ctx ->
+                             resultIsValidShrink (Context.execution ctx) <$>
+                               runProperty prop ctx
+                        )
+                        st
+                        (Counterexample Context.Initial e run, shrunk)
 
                 -- We have to be careful here: if the user specifies a seed, we
                 -- will first /split/ it to run the test (call to splitSMGen,
@@ -198,14 +226,14 @@ data DriverState a = DriverState {
       -- | Accumulated successful tests
     , successes :: [Success a]
 
-      -- | Number of tests still to execute
-    , todo :: Word
-
       -- | Number of tests we discarded so far (for this test)
     , discardedForTest :: Word
 
       -- | Number of tests we discarded (in total)
     , discardedTotal :: Word
+
+      -- | Current test number
+    , thisTest :: Word
     }
   deriving (Show)
 
@@ -219,27 +247,27 @@ initDriverState opts = do
     return $ DriverState {
         prng
       , successes        = []
-      , todo             = tests opts
       , discardedForTest = 0
       , discardedTotal   = 0
+      , thisTest         = 1
       }
 
 withSuccess :: SMGen -> Success a -> DriverState a -> DriverState a
 withSuccess next success acc = DriverState {
       prng             = next
     , successes        = success : successes acc
-    , todo             = pred (todo acc)
     , discardedForTest = 0 -- reset for the next test
     , discardedTotal   = discardedTotal acc
+    , thisTest         = succ (thisTest acc)
     }
 
 withDiscard :: SMGen -> DriverState a -> DriverState a
 withDiscard next acc = DriverState {
       prng             = next
     , successes        = successes acc
-    , todo             = todo acc
     , discardedForTest = succ $ discardedForTest acc
     , discardedTotal   = succ $ discardedTotal acc
+    , thisTest         = thisTest acc
     }
 
 {-------------------------------------------------------------------------------
@@ -333,7 +361,7 @@ renderTestOutcome
                , ""
                , "Logs for each test run below."
                , ""
-               , unlines $ map renderSuccess (zip [1..] successes)
+               , unlines $ map renderSuccess successes
                ]
            }
 
@@ -352,7 +380,7 @@ renderTestOutcome
                , ""
                , "Logs for each test run below."
                , ""
-               , intercalate "\n" $ map renderSuccess (zip [1..] successes)
+               , intercalate "\n" $ map renderSuccess successes
                , showSeed initSeed
                ]
            }
@@ -374,7 +402,7 @@ renderTestOutcome
                    , countHistory history
                    , countDiscarded
                    ]
-               , fst $ NE.last history
+               , counterexampleError $ NE.last history
                ]
            }
          where
@@ -388,9 +416,9 @@ renderTestOutcome
                    , countHistory history
                    , countDiscarded
                    ]
-               , fst $ NE.last history
+               , counterexampleError $ NE.last history
                , "Logs for failed test run:"
-               , renderLog . runLog . snd $ NE.last history
+               , renderLog . runLog . counterexampleRun $ NE.last history
                ]
            }
          where
@@ -400,9 +428,9 @@ renderTestOutcome
              testPassed = False
            , testOutput = unlines [
                  "failed after " ++ countHistory history
-               , fst $ NE.last history
+               , counterexampleError $ NE.last history
                , "Logs for failed test run:"
-               , renderLog . runLog . snd $ NE.last history
+               , renderLog . runLog . counterexampleRun $ NE.last history
                , showSeed $ failureSeed e
                ]
            }
@@ -413,16 +441,16 @@ renderTestOutcome
              testPassed = False
            , testOutput = unlines [
                  "failed after " ++ countHistory history
-               , fst $ NE.last history
+               , counterexampleError $ NE.last history
                , ""
                , "Logs for complete shrink history:"
                , ""
                , intercalate "\n" $ [
                      intercalate "\n" [
-                         "Step " ++ show (step :: Word)
-                       , renderLog (runLog run)
+                         showStep (counterexampleContext example)
+                       , renderLog (runLog $ counterexampleRun example)
                        ]
-                   | (step, (_result, run)) <- zip [1..] (NE.toList history)
+                   | example <- NE.toList history
                    ]
                , showSeed $ failureSeed e
                ]
@@ -443,13 +471,27 @@ renderTestOutcome
 
     -- The history includes the original value, so the number of shrink steps
     -- is the length of the history minus 1.
-    countHistory :: NonEmpty (String, TestRun) -> [Char]
+    countHistory :: NonEmpty (Counterexample String) -> [Char]
     countHistory history = concat [
           if | length successes == 0 -> ""
              | otherwise             -> countSuccess ++ " and "
-        , if | length history   == 2 -> "1 shrink"
-             | otherwise             -> show (length history - 1) ++ " shrinks"
+        , if | numShrinks == 1 -> "1 shrink"
+             | otherwise       -> show numShrinks ++ " shrinks"
         ]
+      where
+        numShrinks :: Word
+        numShrinks =
+            case counterexampleContext $ NE.last history of
+              Context.Final i ->
+                -- Under normal circumstances this is the only expected case
+                i
+              Context.Initial ->
+                -- No shrinking steps at all
+                0
+              Context.Shrinking i ->
+                -- @i@ here is the index of the step, not the number of steps
+                i + 1
+
 
     showSeed :: ReplaySeed -> String
     showSeed seed = "Use --falsify-replay=" ++ show seed ++ " to replay."
@@ -504,10 +546,19 @@ renderTestOutcome
             . runLabels
             . successRun
 
-renderSuccess :: (Int, Success ()) -> String
-renderSuccess (ix, Success{successRun}) =
+    showStep :: Context.Execution -> [Char]
+    showStep = \case
+        Context.Initial ->
+          "Initial counter-example"
+        Context.Shrinking i ->
+          "Shrinking step " ++ show i
+        Context.Final i ->
+          "Final counter-example after " ++ show i ++ " shrink steps"
+
+renderSuccess :: Success () -> String
+renderSuccess Success{successIteration, successRun} =
     intercalate "\n" . concat $ [
-        ["Test " ++ show ix]
+        ["Test " ++ show (Context.thisTest successIteration)]
       , [renderLog $ runLog successRun]
       ]
 

--- a/falsify/src/Test/Falsify/Internal/Generator/Shrinking.hs
+++ b/falsify/src/Test/Falsify/Internal/Generator/Shrinking.hs
@@ -6,6 +6,7 @@ module Test.Falsify.Internal.Generator.Shrinking (
     -- * Support for shrink trees
   , fromShrinkTree
   , toShrinkTree
+  , toShrinkTreeWithContext
   ) where
 
 import Prelude hiding (properFraction)
@@ -18,6 +19,7 @@ import Test.Falsify.Internal.Generator
 import Test.Falsify.SampleTree (SampleTree(..), Sample(..))
 import Test.Falsify.ShrinkTree (ShrinkTree(..))
 
+import qualified Test.Falsify.Context    as Context
 import qualified Test.Falsify.ShrinkTree as ShrinkTree
 
 {-------------------------------------------------------------------------------
@@ -122,10 +124,44 @@ fromShrinkTree = go . unwrapShrinkTree
 
 -- | Expose the full shrink tree of a generator
 --
+-- The generator is passed 'Context.Initial' for the initial step, and then
+-- 'Context.Shrinking' with the number of the shrink step after that. The
+-- 'Test.Falsify.Context.Final' step is /not/ included.
+--
 -- This generator does not shrink.
 toShrinkTree :: forall a. Gen a -> Gen (ShrinkTree a)
-toShrinkTree gen =
-    WrapShrinkTree . Rose.unfoldTree aux . runGen gen <$> captureLocalTree
+toShrinkTree gen = fmap snd <$> toShrinkTreeWithContext False (const gen)
+
+-- | Generalization of 'toShrinkTree'
+toShrinkTreeWithContext :: forall a.
+     Bool -- ^ Include 'Context.Final' step?
+  -> (Context.Execution -> Gen a)
+  -> Gen (ShrinkTree (Context.Execution, a))
+toShrinkTreeWithContext includeFinal gen = do
+    initSeed <- Seed Context.Initial <$> captureLocalTree
+    return $ WrapShrinkTree $ Rose.unfoldTree aux initSeed
   where
-    aux :: (a, [SampleTree]) -> (a, [(a, [SampleTree])])
-    aux (x, shrunk) = (x, map (runGen gen) shrunk)
+    aux :: Seed -> ((Context.Execution, a), [Seed])
+    aux seed@Seed{seedContext, seedSampleTree} =
+        case runGen (gen seedContext) seedSampleTree of
+          (a, shrunk) -> ((seedContext, a), nextSeed seed shrunk)
+
+    nextSeed :: Seed -> [SampleTree] -> [Seed]
+    nextSeed Seed{seedContext, seedSampleTree} shrunk =
+       case seedContext of
+         Context.Initial ->
+           case shrunk of
+             [] | includeFinal -> [Seed (Context.Final 0) seedSampleTree]
+             _  -> map (Seed $ Context.Shrinking 0) shrunk
+         Context.Shrinking i ->
+           case shrunk of
+             [] | includeFinal -> [Seed (Context.Final $ succ i) seedSampleTree]
+             _  -> map (Seed $ Context.Shrinking $ succ i) shrunk
+         Context.Final _ ->
+           []
+
+-- | Internal: 'Rose.unfoldTree' seed, for constructing the shrink tree
+data Seed = Seed{
+      seedContext    :: Context.Execution
+    , seedSampleTree :: SampleTree
+    }

--- a/falsify/src/Test/Falsify/Internal/Property.hs
+++ b/falsify/src/Test/Falsify/Internal/Property.hs
@@ -10,6 +10,7 @@ module Test.Falsify.Internal.Property (
   , runProperty
     -- * Test results
   , TestResult(..)
+  , Counterexample(..)
   , resultIsValidShrink
     -- * State
   , TestRun(..)
@@ -25,18 +26,24 @@ module Test.Falsify.Internal.Property (
   , discard
   , label
   , collect
+  , getContext
+  , sized
     -- * Testing shrinking
   , testShrinking
+  , testShrinkingForIteration
   , testMinimum
+  , testMinimumForIteration
     -- * Testing generators
   , testGen
   , testGen'
   , testShrinkingOfGen
+  , testShrinkingOfGenForIteration
   ) where
 
 import Prelude hiding (log)
 
 import Control.Monad
+import Control.Monad.Reader
 import Control.Monad.State
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty)
@@ -48,10 +55,13 @@ import GHC.Stack
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
+import Data.Falsify.ProperFraction (ProperFraction(..))
+import Test.Falsify.Context (Context(Context))
 import Test.Falsify.Internal.Generator
 import Test.Falsify.Internal.Shrinking
 import Test.Falsify.Predicate (Predicate, (.$))
 
+import qualified Test.Falsify.Context   as Context
 import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 
@@ -60,6 +70,7 @@ import qualified Test.Falsify.Predicate as P
 -------------------------------------------------------------------------------}
 
 data TestRun = TestRun {
+      -- | Any 'info' messages generated during the run
       runLog :: Log
 
       -- | Did we generate any values in this test run?
@@ -101,7 +112,7 @@ initTestRun = TestRun {
 -- This is an internal function, used when testing shrinking to include the runs
 -- from an unshrunk test and a shrunk test.
 appendLog :: Log -> Property' e ()
-appendLog (Log log') = mkProperty $ \run@TestRun{runLog = Log log} -> return (
+appendLog (Log log') = mkProperty $ \_ctx run@TestRun{runLog = Log log} -> return (
       TestPassed ()
     , run{runLog = Log $ log' ++ log}
     )
@@ -127,15 +138,22 @@ data TestResult e a =
   | TestDiscarded
   deriving stock (Show, Functor)
 
--- | A test result is a valid shrink step if the test still fails
+data Counterexample e = Counterexample{
+      counterexampleContext :: Context.Execution
+    , counterexampleError   :: e
+    , counterexampleRun     :: TestRun
+    }
+  deriving (Show)
+
 resultIsValidShrink ::
-     (TestResult e a, TestRun)
-  -> IsValidShrink (e, TestRun) (Maybe a, TestRun)
-resultIsValidShrink (result, run) =
+     Context.Execution
+  -> (TestResult e a, TestRun)
+  -> IsValidShrink (Counterexample e) (Maybe a, TestRun)
+resultIsValidShrink ctxt (result, run) =
     case result of
-      TestFailed e  -> ValidShrink   (e       , run)
-      TestDiscarded -> InvalidShrink (Nothing , run)
-      TestPassed a  -> InvalidShrink (Just a  , run)
+      TestFailed e  -> ValidShrink $ Counterexample ctxt e run
+      TestDiscarded -> InvalidShrink (Nothing, run)
+      TestPassed a  -> InvalidShrink (Just a , run)
 
 {-------------------------------------------------------------------------------
   Monad-transformer version of 'TestResult'
@@ -173,7 +191,7 @@ instance Monad m => Monad (TestResultT e m) where
 -- In most cases, you will probably want to use 'Property'
 -- instead, which fixes @e@ at 'String'.
 newtype Property' e a = WrapProperty {
-      unwrapProperty :: TestResultT e (StateT TestRun Gen) a
+      unwrapProperty :: TestResultT e (ReaderT Context (StateT TestRun Gen)) a
     }
   deriving newtype (Functor, Applicative, Monad)
 
@@ -186,12 +204,13 @@ type Property = Property' String
 -- | Construct property
 --
 -- This is a low-level function for internal use only.
-mkProperty :: (TestRun -> Gen (TestResult e a, TestRun)) -> Property' e a
-mkProperty = WrapProperty . TestResultT . StateT
+mkProperty :: (Context -> TestRun -> Gen (TestResult e a, TestRun)) -> Property' e a
+mkProperty f = WrapProperty $ TestResultT $ ReaderT $ \ctx -> StateT (f ctx)
 
 -- | Run property
-runProperty :: Property' e a -> Gen (TestResult e a, TestRun)
-runProperty = flip runStateT initTestRun . runTestResultT . unwrapProperty
+runProperty :: Property' e a -> Context -> Gen (TestResult e a, TestRun)
+runProperty p ctx =
+    flip runStateT initTestRun $ flip runReaderT ctx $ runTestResultT $ unwrapProperty p
 
 {-------------------------------------------------------------------------------
   'Property' features
@@ -199,18 +218,18 @@ runProperty = flip runStateT initTestRun . runTestResultT . unwrapProperty
 
 -- | Test failure
 testFailed :: e -> Property' e a
-testFailed err = mkProperty $ \run -> return (TestFailed err, run)
+testFailed err = mkProperty $ \_ctx run -> return (TestFailed err, run)
 
 -- | Discard this test
 discard :: Property' e a
-discard = mkProperty $ \run -> return (TestDiscarded, run)
+discard = mkProperty $ \_ctx run -> return (TestDiscarded, run)
 
 -- | Log some additional information about the test
 --
 -- This will be shown in verbose mode.
 info :: String -> Property' e ()
 info msg =
-    mkProperty $ \run@TestRun{runLog = Log log} -> return (
+    mkProperty $ \_ctx run@TestRun{runLog = Log log} -> return (
         TestPassed ()
       , run{runLog = Log $ Info msg : log}
       )
@@ -227,7 +246,7 @@ assert p =
 -- See 'collect' for detailed discussion.
 label :: String -> [String] -> Property' e ()
 label lbl vals =
-    mkProperty $ \run@TestRun{runLabels} -> return (
+    mkProperty $ \_ctx run@TestRun{runLabels} -> return (
         TestPassed ()
       , run{runLabels = Map.alter addValues lbl runLabels}
       )
@@ -299,6 +318,33 @@ collect l = label l . map show
 instance MonadFail (Property' String) where
   fail = testFailed
 
+
+-- | Get the context for the current test run
+getContext :: Property' e Context
+getContext = mkProperty $ \ctx run -> return (TestPassed ctx, run)
+
+-- | Generate value depending on the test iteration
+--
+-- Rough analogue to QuickCheck's @sized@ function: for test iteration @i@ out
+-- of a total of @n@ tests, the callback is passed @i / n@. This can be used for
+-- example to define a t'Test.Falsify.Range.Range' that starts small and gets
+-- larger in successive tests.
+--
+-- Note that this is just a convenience function around 'getContext'; if you
+-- want to define ranges that depend on the test iteration @i@ in a different
+-- way, use 'getContext' instead.
+sized :: forall e a. (ProperFraction -> a) -> Property' e a
+sized f =
+    aux <$> getContext
+  where
+    aux :: Context -> a
+    aux ctxt =
+        f $ ProperFraction $ thisTest / numTests
+      where
+        thisTest, numTests :: Double
+        thisTest = fromIntegral . Context.thisTest . Context.iteration $ ctxt
+        numTests = fromIntegral . Context.tests    . Context.static    $ ctxt
+
 {-------------------------------------------------------------------------------
   Running generators
 -------------------------------------------------------------------------------}
@@ -309,7 +355,7 @@ genWithCallStack :: forall e a.
                          -- (users don't care that 'gen' uses 'genWith').
   -> (a -> Maybe String) -- ^ Entry to add to the log (if any)
   -> Gen a -> Property' e a
-genWithCallStack stack f g = mkProperty $ \run -> aux run <$> g
+genWithCallStack stack f g = mkProperty $ \_ctx run -> aux run <$> g
   where
     aux :: TestRun -> a -> (TestResult e a, TestRun)
     aux run@TestRun{runLog = Log log} x = (
@@ -336,17 +382,31 @@ genWith = genWithCallStack callStack
 -------------------------------------------------------------------------------}
 
 -- | Construct random path through the property's shrink tree
-genShrinkPath :: Property' e () -> Property' e' [(e, TestRun)]
-genShrinkPath prop = do
+--
+-- The repeated 'Context.Final' step is /not/ included.
+genShrinkPath ::
+     Context.Iteration -- ^ See 'testShrinking' for detailed discussion
+  -> Property' e ()
+  -> Property' e' [Counterexample e]
+genShrinkPath iteration prop = do
+    static <- Context.static <$> getContext
+
+    let ctx :: Context.Execution -> Context
+        ctx = Context static iteration
+
     st    <- genWith (const Nothing) $
-               Gen.toShrinkTree (runProperty prop)
+               Gen.toShrinkTreeWithContext False (runProperty prop . ctx)
     mPath <- genWith (const Nothing) $
-               Gen.path (isValidShrink . resultIsValidShrink) st
+               Gen.path
+                 ( \(exe, (result, run)) ->
+                      isValidShrink $ resultIsValidShrink exe (result, run)
+                 )
+                 st
     aux mPath
   where
     aux ::
-         Either (Maybe (), TestRun) (NonEmpty (e, TestRun))
-      -> Property' e' [(e, TestRun)]
+         Either (Maybe (), TestRun) (NonEmpty (Counterexample e))
+      -> Property' e' [Counterexample e]
     aux (Left (Just (), _)) = return []
     aux (Left (Nothing, _)) = discard
     aux (Right es)          = return $ toList es
@@ -363,11 +423,40 @@ genShrinkPath prop = do
 -- If the given property itself discards immediately, then this generator will
 -- discard also; otherwise, only shrink steps are considered that do not lead
 -- to a discard.
+--
+-- See also 'testShrinkingForIteration'.
 testShrinking :: forall e.
      Show e
-  => Predicate [e, e] -> Property' e () -> Property' String ()
-testShrinking p prop = do
-    path <- genShrinkPath prop
+  => Predicate [e, e]
+  -> Property' e () -> Property' String ()
+testShrinking = testShrinkingForIteration $ Context.Iteration{
+      thisTest = error $ concat [
+          "thisTest is undefined. "
+        , "Use testShrinkingForIteration "
+        , "instead of testShrinking."
+        ]
+    }
+
+-- | Generalization of 'testShrinking' for an arbitrary t'Test.Falsify.Context.Iteration'
+--
+-- Some properties may behave quite differently given a different iteration
+-- context, in which case it is important to be explicit about this.
+--
+-- The /shrinking/ context is constructed so that it accurately reflects the
+-- path: 'Context.Initial' for the root of the tree, and then
+-- 'Context.Shrinking' as we follow edges downwards. There is /no/ repeated
+-- 'Context.Final' step: 'testShrinkingForIteration' and 'testShrinking' are
+-- typically used to verify that successive shrink steps result in values that
+-- are closer to the generator's origin, which is trivially violated by that
+-- repeated final step.
+--
+-- The /static/ context is inherited from the parent property.
+testShrinkingForIteration :: forall e.
+     Show e
+  => Context.Iteration
+  -> Predicate [e, e] -> Property' e () -> Property' String ()
+testShrinkingForIteration iteration p prop = do
+    path <- genShrinkPath iteration prop
     case findCounterExample (toList path) of
       Nothing ->
         return ()
@@ -378,14 +467,20 @@ testShrinking p prop = do
         appendLog logAfter
         testFailed err
   where
-    findCounterExample :: [(e, TestRun)] -> Maybe (String, Log, Log)
+    findCounterExample :: [Counterexample e] -> Maybe (String, Log, Log)
     findCounterExample = \case
         []  -> Nothing
         [_] -> Nothing
-        ((x, runX) : rest@((y, runY) : _)) ->
-          case P.eval $ p .$ ("original", x) .$ ("shrunk", y) of
-            Left err -> Just (err, runLog runX, runLog runY)
+        (x : rest@(y : _)) ->
+          case P.eval $
+                 p .$ ("original" , counterexampleError x)
+                   .$ ("shrunk"   , counterexampleError y) of
             Right () -> findCounterExample rest
+            Left err -> Just (
+                err
+              , runLog (counterexampleRun x)
+              , runLog (counterexampleRun y)
+              )
 
 -- | Test the minimum error thrown by the property
 --
@@ -397,14 +492,32 @@ testShrinking p prop = do
 -- some particular property in mind. Otherwise, the minimum value will always
 -- simply be the value that the generator produces when given the @Minimal@
 -- sample tree.
-testMinimum :: forall e.
+--
+-- See also 'testMinimumForIteration'.
+testMinimum :: Show e => Predicate '[e] -> Property' e () -> Property' String ()
+testMinimum = testMinimumForIteration $ Context.Iteration{
+          thisTest = error $ concat [
+              "thisTest is undefined. "
+            , "Use testMinimumForIteration "
+            , "instead of testMinimum."
+            ]
+        }
+
+-- | Generalization of 'testMinimum'
+--
+-- See 'testShrinkingForIteration' for detailed discussion of the context.
+testMinimumForIteration :: forall e.
      Show e
-  => Predicate '[e]
-  -> Property' e ()
-  -> Property' String ()
-testMinimum p prop = do
+  => Context.Iteration
+  -> Predicate '[e] -> Property' e () -> Property' String ()
+testMinimumForIteration iteration p prop = do
+    static <- Context.static <$> getContext
+
+    let initContext :: Context
+        initContext = Context static iteration Context.Initial
+
     st <- genWith (const Nothing) $ Gen.captureLocalTree
-    case runGen (runProperty prop) st of
+    case runGen (runProperty prop initContext) st of
       ((TestPassed (), _run), _shrunk) ->
         -- The property passed; nothing to test
         discard
@@ -412,30 +525,33 @@ testMinimum p prop = do
         -- The property needs to be discarded; discard this one, too
         discard
       ((TestFailed initErr, initRun), shrunk) -> do
-        let explanation :: ShrinkExplanation (e, TestRun) (Maybe (), TestRun)
-            explanation = shrinkFrom
-                            resultIsValidShrink
-                            (runProperty prop)
-                            ((initErr, initRun), shrunk)
+        let explanation :: ShrinkExplanation (Counterexample e) (Maybe (), TestRun)
+            explanation =
+                shrinkFrom
+                  static
+                  iteration
+                  (\ctx -> resultIsValidShrink (Context.execution ctx) <$>
+                             runProperty prop ctx)
+                  st
+                  (Counterexample Context.Initial initErr initRun, shrunk)
 
-            minErr    :: e
-            minRun    :: TestRun
-            mRejected :: Maybe [(Maybe (), TestRun)]
-            ((minErr, minRun), mRejected) = shrinkOutcome explanation
+            minExample :: Counterexample e
+            mRejected  :: Maybe [(Maybe (), TestRun)]
+            (minExample, mRejected) = shrinkOutcome explanation
 
             rejected :: [TestRun]
             rejected  = maybe [] (map snd) mRejected
 
-        case P.eval $ p .$ ("minimum", minErr) of
+        case P.eval $ p .$ ("minimum", counterexampleError minExample) of
           Right () -> do
             -- For a successful test, we add the full shrink history as info
             -- This means that users can use verbose mode to see precisely
             -- how the minimum value is reached, if they wish.
             info "Shrink history:"
-            forM_ (shrinkHistory explanation) $ \(e, _run) ->
-              info $ show e
+            forM_ (shrinkHistory explanation) $ \example ->
+              info $ show (counterexampleError example)
           Left err -> do
-            appendLog (runLog minRun)
+            appendLog (runLog $ counterexampleRun minExample)
             unless (null rejected) $ do
               info "\nLogs for rejected potential next shrinks:"
               forM_ (zip [0 :: Word ..] rejected) $ \(i, rej) -> do
@@ -453,7 +569,7 @@ testGen p = testGen' $ \a -> P.eval $ p .$ ("generated", a)
 
 -- | Generalization of 'testGen'
 testGen' :: forall e a b. (a -> Either e b) -> Gen a -> Property' e b
-testGen' p g = WrapProperty $ TestResultT $ StateT $ \run ->
+testGen' p g = WrapProperty $ TestResultT $ ReaderT $ \_ctx -> StateT $ \run ->
     -- We do not use bind here to avoid introducing new shrinking shortcuts
     aux run <$> g
   where
@@ -469,5 +585,24 @@ testGen' p g = WrapProperty $ TestResultT $ StateT $ \run ->
 --
 -- We check /any/ shrink step that the generator can make (independent of any
 -- property).
+--
+-- See also 'testShrinkingOfGenForIteration'.
 testShrinkingOfGen :: Show a => Predicate [a, a] -> Gen a -> Property' String ()
-testShrinkingOfGen p = testShrinking p . testGen' Left
+testShrinkingOfGen =
+    testShrinkingOfGenForIteration $ Context.Iteration{
+          thisTest = error $ concat [
+              "thisTest is undefined. "
+            , "Use testShrinkingOfGenForIteration "
+            , "instead of testShrinkingOfGen."
+            ]
+        }
+
+-- | Generalization of 'testShrinkingOfGen'
+--
+-- See 'testShrinkingForIteration' for detailed discussion of the context.
+testShrinkingOfGenForIteration ::
+     Show a
+  => Context.Iteration
+  -> Predicate [a, a] -> Gen a -> Property' String ()
+testShrinkingOfGenForIteration iteration p =
+    testShrinkingForIteration iteration p . testGen' Left

--- a/falsify/src/Test/Falsify/Internal/Shrinking.hs
+++ b/falsify/src/Test/Falsify/Internal/Shrinking.hs
@@ -6,7 +6,6 @@ module Test.Falsify.Internal.Shrinking (
   , ShrinkHistory(..)
   , IsValidShrink(..)
   , isValidShrink
-  , limitShrinkSteps
   , shrinkHistory
   , shrinkOutcome
   ) where
@@ -15,8 +14,11 @@ import Data.Bifunctor
 import Data.Either
 import Data.List.NonEmpty (NonEmpty((:|)))
 
+import Test.Falsify.Context (Context(Context))
 import Test.Falsify.Internal.Generator
 import Test.Falsify.SampleTree (SampleTree(..))
+
+import qualified Test.Falsify.Context as Context
 
 {-------------------------------------------------------------------------------
   Explanation
@@ -42,31 +44,22 @@ data ShrinkHistory p n =
 
     -- | We could no shrink any further
     --
-    -- We also record all rejected next steps. This is occasionally useful when
-    -- trying to figure out why a value didn't shrink any further (what did it
-    -- try to shrink to?)
-  | ShrinkingDone [n]
+    -- We record
+    --
+    -- * All rejected next steps
+    -- * The outcome of the repeated 'Context.Final' step
+    --
+    -- Recording the rejected next steps is occasionally useful when trying to
+    -- figure out why a value didn't shrink any further (what did it try to
+    -- shrink to?).
+  | ShrinkingDone [n] p
 
     -- | We stopped shrinking early
     --
     -- This is used when the number of shrink steps is limited.
-  | ShrinkingStopped
+    -- We record the outcome of the repeated 'Context.Final' step.
+  | ShrinkingStopped p
   deriving (Show)
-
-limitShrinkSteps :: Maybe Word -> ShrinkExplanation p n -> ShrinkExplanation p n
-limitShrinkSteps Nothing      = id
-limitShrinkSteps (Just limit) = \case
-    ShrinkExplanation{initial, history} ->
-      ShrinkExplanation{
-          initial
-        , history = go limit history
-        }
-  where
-    go :: Word -> ShrinkHistory p n -> ShrinkHistory p n
-    go 0 (ShrunkTo _ _)      = ShrinkingStopped
-    go n (ShrunkTo x xs)     = ShrunkTo x (go (pred n) xs)
-    go _ (ShrinkingDone rej) = ShrinkingDone rej
-    go _ ShrinkingStopped    = ShrinkingStopped
 
 -- | Simplify the shrink explanation to keep only the shrink history
 shrinkHistory :: ShrinkExplanation p n -> NonEmpty p
@@ -74,26 +67,26 @@ shrinkHistory = \(ShrinkExplanation unshrunk shrunk) ->
     unshrunk :| go shrunk
   where
     go :: ShrinkHistory p n -> [p]
-    go (ShrunkTo x xs)   = x : go xs
-    go (ShrinkingDone _) = []
-    go ShrinkingStopped  = []
+    go (ShrunkTo x xs)       = x : go xs
+    go (ShrinkingDone _ns p) = [p]
+    go (ShrinkingStopped  p) = [p]
 
 -- | The final shrunk value, as well as all rejected /next/ shrunk steps
 --
 -- The list of rejected next steps is
 --
--- * @Nothing@ if shrinking was terminated early ('limitShrinkSteps')
+-- * @Nothing@ if shrinking was terminated early (e.g. 'Context.maxShrinks')
 -- * @Just []@ if the final value truly is minimal (typically, it is only
 --   minimal wrt to a particular properly, but not the minimal value that a
 --   generator can produce).
 shrinkOutcome :: forall p n. ShrinkExplanation p n -> (p, Maybe [n])
-shrinkOutcome = \ShrinkExplanation{initial, history} ->
-    go initial history
+shrinkOutcome = \ShrinkExplanation{history} ->
+    go history
   where
-    go :: p -> ShrinkHistory p n -> (p, Maybe [n])
-    go _ (ShrunkTo p h)     = go p h
-    go p (ShrinkingDone ns) = (p, Just ns)
-    go p  ShrinkingStopped  = (p, Nothing)
+    go :: ShrinkHistory p n -> (p, Maybe [n])
+    go (ShrunkTo _p h)      = go h
+    go (ShrinkingDone ns p) = (p, Just ns)
+    go (ShrinkingStopped p) = (p, Nothing)
 
 {-------------------------------------------------------------------------------
   Mapping
@@ -113,12 +106,9 @@ instance Bifunctor ShrinkExplanation where
 
 instance Bifunctor ShrinkHistory where
   bimap f g = \case
-      ShrunkTo truncated history ->
-        ShrunkTo (f truncated) (bimap f g history)
-      ShrinkingDone rejected ->
-        ShrinkingDone (map g rejected)
-      ShrinkingStopped ->
-        ShrinkingStopped
+      ShrunkTo         p h -> ShrunkTo                 (f p) (bimap f g h)
+      ShrinkingDone ns p   -> ShrinkingDone (map g ns) (f p)
+      ShrinkingStopped p   -> ShrinkingStopped         (f p)
 
 {-------------------------------------------------------------------------------
   Shrinking
@@ -142,33 +132,74 @@ isValidShrink (InvalidShrink n) = Left n
 -- To avoid boolean blindness, we use different types for values that satisfy
 -- the property and values that do not.
 --
--- This is lazy in the shrink history; see 'limitShrinkSteps' to limit the
--- number of shrinking steps.
-shrinkFrom :: forall a p n.
-     (a -> IsValidShrink p n)
-  -> Gen a
-  -> (p, [SampleTree]) -- ^ Initial result of the generator
+-- This is lazy in the shrink history.
+shrinkFrom :: forall p n.
+     Context.Static
+     -- ^ Static context
+     --
+     -- Passed as-is to the property as part of the t'Context'.
+     -- Used to extract shrinking parameters.
+  -> Context.Iteration
+     -- ^ Iteration context
+     --
+     -- Passsed as-is to the property as part of the t'Context'.
+     -- Not used otherwise.
+  -> (Context -> Gen (IsValidShrink p n))
+     -- ^ The property we're shrinking
+  -> SampleTree
+     -- ^ The sample tree we started with
+  -> (p, [SampleTree])
+     -- ^ The initial result of the generator
   -> ShrinkExplanation p n
-shrinkFrom prop gen = \(p, shrunk) ->
-    ShrinkExplanation p $ go shrunk
+shrinkFrom static iteration prop = \st (p, shrunk) ->
+    ShrinkExplanation p $ go 0 st shrunk
   where
-    go :: [SampleTree] -> ShrinkHistory p n
-    go shrunk =
-        -- Shrinking is a greedy algorithm: we go with the first candidate that
-        -- works, and discard the others.
-        --
+    go :: Word -> SampleTree -> [SampleTree] -> ShrinkHistory p n
+    go i = \st shrunk ->
         -- NOTE: 'partitionEithers' is lazy enough:
         --
         -- > head . fst $ partitionEithers [Left True, undefined] == True
-        case partitionEithers candidates of
-          ([], rejected)      -> ShrinkingDone rejected
-          ((p, shrunk'):_, _) -> ShrunkTo p $ go shrunk'
-      where
-        candidates :: [Either (p, [SampleTree]) n]
-        candidates = map consider $ map (runGen gen) shrunk
+        let candidates :: [(SampleTree, p, [SampleTree])]
+            rejected   :: [n]
+            (candidates, rejected) = partitionEithers $ map consider shrunk
 
-    consider :: (a, [SampleTree]) -> Either (p, [SampleTree]) n
-    consider (a, shrunk) =
-        case prop a of
-          ValidShrink p   -> Left (p, shrunk)
-          InvalidShrink n -> Right n
+         in case candidates of
+              [] ->
+                ShrinkingDone rejected $ runFinal i st
+              (st', p, shrunk'):_ | canContinue ->
+                ShrunkTo p $ go (succ i) st' shrunk'
+              _otherwise ->
+                ShrinkingStopped $ runFinal i st
+      where
+        ctx :: Context
+        ctx = Context static iteration $ Context.Shrinking i
+
+        canContinue :: Bool
+        canContinue =
+             maybe
+               True
+               (\limit -> i < limit)
+               (Context.maxShrinks static)
+
+        consider :: SampleTree -> Either (SampleTree, p, [SampleTree]) n
+        consider st =
+            case isValid of
+              ValidShrink p   -> Left (st, p, shrunk')
+              InvalidShrink n -> Right n
+          where
+            isValid :: IsValidShrink p n
+            shrunk' :: [SampleTree]
+            (isValid, shrunk') = runGen (prop ctx) st
+
+    -- Run the property one final time
+    --
+    -- Precondition: must be run on a sample tree for which we know the
+    -- property fails.
+    runFinal :: Word -> SampleTree -> p
+    runFinal i st =
+        case fst $ runGen (prop ctx) st of
+          ValidShrink   p -> p
+          InvalidShrink _ -> error "runFinal: precondition violated"
+      where
+        ctx :: Context
+        ctx = Context static iteration $ Context.Final i

--- a/falsify/src/Test/Falsify/ShrinkTree.hs
+++ b/falsify/src/Test/Falsify/ShrinkTree.hs
@@ -20,6 +20,10 @@ import qualified Data.Tree as Rose
 newtype ShrinkTree a = WrapShrinkTree{
       unwrapShrinkTree :: Rose.Tree a
     }
+  deriving stock (Eq, Functor)
+
+instance Show a => Show (ShrinkTree a) where
+  show = Rose.drawTree . fmap show . unwrapShrinkTree
 
 {-------------------------------------------------------------------------------
   Construction

--- a/falsify/test/TestSuite/Sanity/Predicate.hs
+++ b/falsify/test/TestSuite/Sanity/Predicate.hs
@@ -2,16 +2,25 @@
 
 module TestSuite.Sanity.Predicate (tests) where
 
+import Data.Char
 import Test.Tasty
 import Test.Tasty.HUnit
-import Test.Falsify.Predicate (Predicate, (.$))
+
+import Test.Falsify
 import qualified Test.Falsify.Predicate as P
-import Data.Char
+
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
 
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Predicate" [
       testCase "on" test_on
     ]
+
+{-------------------------------------------------------------------------------
+  Test: 'P.on'
+-------------------------------------------------------------------------------}
 
 test_on :: Assertion
 test_on = do

--- a/falsify/test/TestSuite/Sanity/Range.hs
+++ b/falsify/test/TestSuite/Sanity/Range.hs
@@ -17,6 +17,10 @@ import Test.Falsify
 import qualified Data.Falsify.WordN as WordN
 import qualified Test.Falsify.Range as Range
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Range" [
       testGroup "between" [
@@ -24,6 +28,10 @@ tests = testGroup "TestSuite.Sanity.Range" [
         | size <- [2, 3, 4, 10, 100, 1000, 10_000]
         ]
     ]
+
+{-------------------------------------------------------------------------------
+  Test: 'between'
+-------------------------------------------------------------------------------}
 
 test_between :: Word -> Assertion
 test_between size = do

--- a/falsify/test/TestSuite/Sanity/Selective.hs
+++ b/falsify/test/TestSuite/Sanity/Selective.hs
@@ -12,6 +12,10 @@ import Test.Falsify.Interactive (sample, shrink')
 
 import qualified Test.Falsify.Generator as Gen
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
 tests = testGroup "TestSuite.Sanity.Selective" [
       testGroup "tree" [

--- a/tasty-falsify/CHANGELOG.md
+++ b/tasty-falsify/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for falsify
 
-## 0.1.0 -- ??
+## 0.1.0 -- 2026-07-01
 
 * First release.
   Prior to `falsify-0.4.0`, `tasty` integration was provided by the main package

--- a/tasty-falsify/tasty-falsify.cabal
+++ b/tasty-falsify/tasty-falsify.cabal
@@ -103,6 +103,7 @@ test-suite test-tasty-falsify
       Main.hs
   other-modules:
       TestSuite.Generator.Compound
+      TestSuite.Generator.Context
       TestSuite.Generator.Function
       TestSuite.Generator.Marking
       TestSuite.Generator.Precision

--- a/tasty-falsify/test/Main.hs
+++ b/tasty-falsify/test/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Test.Tasty
 
 import qualified TestSuite.Generator.Compound
+import qualified TestSuite.Generator.Context
 import qualified TestSuite.Generator.Function
 import qualified TestSuite.Generator.Marking
 import qualified TestSuite.Generator.Precision
@@ -15,6 +16,7 @@ main :: IO ()
 main = defaultMain $ testGroup "falsify" [
       testGroup "Generator" [
           TestSuite.Generator.Prim.tests
+        , TestSuite.Generator.Context.tests
         , TestSuite.Generator.Selective.tests
         , TestSuite.Generator.Marking.tests
         , TestSuite.Generator.Precision.tests

--- a/tasty-falsify/test/TestSuite/Generator/Compound.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Compound.hs
@@ -23,8 +23,12 @@ import qualified Test.Falsify.ShrinkTree  as ShrinkTree
 
 import TestSuite.Util.List
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Compound" [
+tests = testGroup "TestSuite.Generator.Compound" [
       testGroup "list" [
           testGroup "towardsShorter" [
               testProperty "shrinking" prop_list_towardsShorter_shrinking
@@ -275,7 +279,6 @@ prop_toShrinkTree =
 
     genToTest :: Gen Word64
     genToTest = (`mod` 100) <$> Gen.prim
-
 
 {-------------------------------------------------------------------------------
   Tweak test data distribution

--- a/tasty-falsify/test/TestSuite/Generator/Context.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Context.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestSuite.Generator.Context (tests) where
+
+import Test.Tasty
+import Test.Tasty.Falsify
+
+import qualified Data.Tree as Rose
+
+import Test.Falsify
+import Test.Falsify.SampleTree (Sample(..))
+
+import qualified Test.Falsify.Context   as Context
+import qualified Test.Falsify.Generator as Gen
+import qualified Test.Falsify.Predicate as P
+import Data.Bifunctor
+
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "TestSuite.Generator.Context" [
+      testGroup "Sanity" [
+          testProperty "toShrinkTree1" sanity_toShrinkTree1
+        , testProperty "toShrinkTree2" sanity_toShrinkTree2
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  'toShrinkTree'
+-------------------------------------------------------------------------------}
+
+sanity_toShrinkTree1 :: Property ()
+sanity_toShrinkTree1 = do
+    shrinkTree <- gen $ Gen.toShrinkTreeWithContext True (const g)
+    assert $
+      P.expect expected `P.dot` P.transparent hideNotShrunk
+        .$ ("shrinkTree", shrinkTree)
+  where
+    g :: Gen Sample
+    g = Gen.primWith (\case
+          NotShrunk _ -> [0..2]
+          Shrunk    0 -> []
+          Shrunk    1 -> [0]
+          Shrunk    x -> [0, x - 1]
+        )
+
+    expected :: ShrinkTree (Context.Execution, Sample)
+    expected = WrapShrinkTree $
+        Rose.Node (Context.Initial, NotShrunk 0) [
+            Rose.Node (Context.Shrinking 0, Shrunk 0) [
+                Rose.Node (Context.Final 1, Shrunk 0) []
+              ]
+          , Rose.Node (Context.Shrinking 0, Shrunk 1) [
+                Rose.Node (Context.Shrinking 1, Shrunk 0) [
+                    Rose.Node (Context.Final 2, Shrunk 0) []
+                  ]
+              ]
+          , Rose.Node (Context.Shrinking 0, Shrunk 2) [
+                Rose.Node (Context.Shrinking 1, Shrunk 0) [
+                    Rose.Node (Context.Final 2, Shrunk 0) []
+                  ]
+              , Rose.Node (Context.Shrinking 1, Shrunk 1) [
+                    Rose.Node (Context.Shrinking 2, Shrunk 0) [
+                        Rose.Node (Context.Final 3,Shrunk 0) []
+                      ]
+                  ]
+              ]
+          ]
+
+sanity_toShrinkTree2 :: Property ()
+sanity_toShrinkTree2 = do
+    shrinkTree <- gen $ Gen.toShrinkTreeWithContext True (const g)
+    assert $
+      P.expect expected `P.dot` P.transparent hideNotShrunk
+        .$ ("shrinkTree", shrinkTree)
+  where
+    g :: Gen Sample
+    g = Gen.primWith (const [])
+
+    expected :: ShrinkTree (Context.Execution, Sample)
+    expected = WrapShrinkTree $
+        Rose.Node (Context.Initial, NotShrunk 0) [
+            Rose.Node (Context.Final 0, NotShrunk 0) []
+          ]
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+-- | \"Hide\" unshrunk samples, so that we have deterministic output
+hideNotShrunk :: ShrinkTree (ctxt, Sample) -> ShrinkTree (ctxt, Sample)
+hideNotShrunk = fmap . second $ \case
+    NotShrunk _ -> NotShrunk 0
+    Shrunk    x -> Shrunk    x

--- a/tasty-falsify/test/TestSuite/Generator/Function.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Function.hs
@@ -15,8 +15,12 @@ import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 import qualified Test.Falsify.Range     as Range
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Function" [
+tests = testGroup "TestSuite.Generator.Function" [
       testGroup "BoolToBool" [
           testProperty "notConstant" prop_BoolToBool_notConstant
         , testProperty "constant"    prop_BoolToBool_constant

--- a/tasty-falsify/test/TestSuite/Generator/Marking.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Marking.hs
@@ -19,8 +19,12 @@ import qualified Test.Falsify.Predicate as P
 
 import TestSuite.Util.List
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Marking" [
+tests = testGroup "TestSuite.Generator.Marking" [
       testGroup "list" [
           testProperty "shrinking" prop_list_shrinking
         , testProperty "minimum"   prop_list_minimum

--- a/tasty-falsify/test/TestSuite/Generator/Precision.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Precision.hs
@@ -13,8 +13,12 @@ import qualified Data.Falsify.WordN     as WordN
 import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Precision" [
+tests = testGroup "TestSuite.Generator.Precision" [
       testGroup "wordN" [
           testGroup (show p) [
               testProperty "shrinking" $ prop_wordN_shrinking p

--- a/tasty-falsify/test/TestSuite/Generator/Prim.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Prim.hs
@@ -17,8 +17,12 @@ import qualified Test.Falsify.Predicate as P
 
 import TestSuite.Util.List
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Prim" [
+tests = testGroup "TestSuit.Generator.Prim" [
     testGroup "prim" [
         testProperty "shrinking" prop_prim_shrinking
       , testGroup "minimum" [

--- a/tasty-falsify/test/TestSuite/Generator/Selective.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Selective.hs
@@ -13,8 +13,12 @@ import Test.Falsify
 import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Selective" [
+tests = testGroup "TestSuite.Generator.Selective" [
       testGroup "pair" [
           testProperty                   "ifM"        $ prop_pair ifM
         , testPropertyWith expectFailure "ifS"        $ prop_pair ifS

--- a/tasty-falsify/test/TestSuite/Generator/Shrinking.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Shrinking.hs
@@ -20,8 +20,12 @@ import qualified Test.Falsify.Range as Range
 
 import TestSuite.Util.List
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Shrinking" [
+tests = testGroup "TestSuite.Generator.Shrinking" [
       testGroup "prim" [
           testPropertyWith expectFailure  "prim" prop_prim_minimum
         ]

--- a/tasty-falsify/test/TestSuite/Generator/Simple.hs
+++ b/tasty-falsify/test/TestSuite/Generator/Simple.hs
@@ -16,8 +16,12 @@ import qualified Test.Falsify.Generator as Gen
 import qualified Test.Falsify.Predicate as P
 import qualified Test.Falsify.Range     as Range
 
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
 tests :: TestTree
-tests = testGroup "TestSuite.Prop.Generator.Simple" [
+tests = testGroup "TestSuite.Generator.Simple" [
     testGroup "prim" [
         testProperty "shrinking" prop_prim_shrinking
       , testGroup "minimum" [


### PR DESCRIPTION
This takes the ideas from #102 and propagates them a bit more thoroughly, addressing the review feedback.

@DigitalBrains1 , @martijnbastiaan , I _think_ this is now good to merge, though I might write a few more tests, and I still need to update the changelog. Let me know if anything here looks off! Key changes compared to the original PR are

* `ShrinkHistory` is now explicit about recording the final "repeated" test step
* The `Context` is split into three parts, as discussed; `Context.Execution` provides the excecution context
* `shrinkFrom` now actually does that final execution step; together with the previous point, this I think clarifies the logic quite a bit.

The rest of this PR is _basically_ just propagation, and being more explicit about the new `Context`.

There is now also a very simple demo:

```hs
demo1 :: Property ()
demo1 = do
    x    <- gen Gen.prim
    ctxt <- getContext
    info $ concat [
        "demo1: "
      , "generated " ++ show x
      , " in step " ++ show (Context.execution ctxt)
      ]
    assert $ P.expect 0 .$ ("x", x)
```

When we run this with `--falsify-verbose`, we get

```
      failed after 64 shrinks
      expected /= x
      expected: 0
      x       : 1
      
      
      Logs for complete shrink history:
      
      Initial counter-example
      generated 9290267825672405245 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 9290267825672405245 in step Initial
      
      Shrinking step 0
      generated 4645133912836202623 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 4645133912836202623 in step Shrinking 0
      
      Shrinking step 1
      generated 2322566956418101312 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 2322566956418101312 in step Shrinking 1
      
      Shrinking step 2
      generated 1161283478209050656 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 1161283478209050656 in step Shrinking 2
      
      (..)

      Shrinking step 62
      generated 2 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 2 in step Shrinking 62
      
      Shrinking step 63
      generated 1 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 1 in step Shrinking 63
      
      Final counter-example after 64 shrink steps
      generated 1 at CallStack (from HasCallStack):
        gen, called at demo/Demo/Context.hs:27:13 in demo-0.1.0-inplace-demo:Demo.Context
      demo1: generated 1 in step Final 64
      
      Use --falsify-replay=015e40ff5754feb5a4bb04852954f0a09f to replay.
```

(The duplication here is intentional, and specific to this demo: the headers "Shrinking step 63" from from the `Driver`, the text "demo1: generated 1 in step Shrinking 63" is an `info` message from the demo itself.)